### PR TITLE
feat: add Leaflet map view and coordinate utilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2191,6 +2192,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,35 +1,7 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import MapView from './MapView'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <MapView />
 }
 
 export default App

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+function MapView() {
+  const mapRef = useRef(null);
+
+  useEffect(() => {
+    if (mapRef.current) return; // prevent reinitialization
+    const map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    mapRef.current = map;
+  }, []);
+
+  return <div id="map" style={{ height: '100vh', width: '100%' }}></div>;
+}
+
+export default MapView;

--- a/client/src/utils/coords.js
+++ b/client/src/utils/coords.js
@@ -1,0 +1,26 @@
+// Coordinate conversion utilities ported from Umap.pas
+
+// Converts world coordinate X,Y to pixel coordinates based on map window properties
+export function worldToPixel(x, y, window) {
+  const px = Math.round((x - window.Woffset.X) / window.WperP) + window.Poffset.X;
+  const py = window.Poffset.Y - Math.round((y - window.Woffset.Y) / window.WperP);
+  return { x: px, y: py };
+}
+
+// Converts pixel coordinates to world coordinates
+export function pixelToWorld(px, py, window) {
+  const x = (px - window.Poffset.X) * window.WperP + window.Woffset.X;
+  const y = (window.Poffset.Y - py) * window.WperP + window.Woffset.Y;
+  return { x, y };
+}
+
+// Convert map units to project units (degrees to meters)
+export function convertMapUnits(dx, dy, dimensions) {
+  if (dimensions.units === 'degrees') {
+    return {
+      dx: dx * dimensions.XperDeg,
+      dy: dy * dimensions.YperDeg
+    };
+  }
+  return { dx, dy };
+}


### PR DESCRIPTION
## Summary
- install Leaflet in client app
- add MapView component initializing a Leaflet map with OSM tiles
- port Pascal coordinate conversion helpers to JavaScript utilities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbb30d6de48332bc019ecdda4d6fa3