### PR TITLE
chore: proxy api requests in dev

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy /api requests from Vite dev server to backend

## Testing
- `npm run lint`
- `curl -i http://localhost:5173/api/output`

------
https://chatgpt.com/codex/tasks/task_e_68bbbdc4435c8332a5fa4c60fbecca8d