### PR TITLE
feat: add Leaflet map view and coordinate utilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2191,6 +2192,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import './App.css'
+import MapView from './MapView.jsx'
 
 function App() {
   const [output, setOutput] = useState('Loading...')
@@ -15,6 +16,7 @@ function App() {
     <div>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
+      <MapView />
     </div>
   )
 }

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+function MapView() {
+  const mapRef = useRef(null)
+
+  useEffect(() => {
+    if (!mapRef.current) return
+    const map = L.map(mapRef.current).setView([0, 0], 2)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map)
+  }, [])
+
+  return <div ref={mapRef} style={{ height: '400px', width: '100%' }} />
+}
+
+export default MapView

--- a/client/src/utils/coords.js
+++ b/client/src/utils/coords.js
@@ -1,0 +1,20 @@
+// Coordinate conversion utilities ported from Umap.pas
+// Window: { WperP: number, Woffset: { x: number, y: number }, Poffset: { x: number, y: number } }
+
+export function worldToPixelX(x, window) {
+  const p = (x - window.Woffset.x) / window.WperP
+  return Math.round(p) + window.Poffset.x
+}
+
+export function worldToPixelY(y, window) {
+  const p = (y - window.Woffset.y) / window.WperP
+  return window.Poffset.y - Math.round(p)
+}
+
+export function pixelToWorldX(x, window) {
+  return (x - window.Poffset.x) * window.WperP + window.Woffset.x
+}
+
+export function pixelToWorldY(y, window) {
+  return (window.Poffset.y - y) * window.WperP + window.Woffset.y
+}


### PR DESCRIPTION
## Summary
- install Leaflet in the frontend
- add MapView component with OSM tiles
- port coordinate conversion helpers from Umap.pas

## Testing
- `npm run lint`
- `nohup npm run dev >/tmp/dev.log 2>&1 &`
- `curl -s http://localhost:5173 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68bbbdab13b48332ac97344d6bcb4815