### PR TITLE
feat: add responsive map container styles

### DIFF
--- a/client/src/MapView.css
+++ b/client/src/MapView.css
@@ -1,0 +1,5 @@
+.map-container {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+}

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import './MapView.css';
 
 function MapView() {
   const mapRef = useRef(null);
@@ -16,7 +17,7 @@ function MapView() {
     };
   }, []);
 
-  return <div ref={mapRef} style={{ height: '400px', width: '100%' }} />;
+  return <div ref={mapRef} className="map-container" />;
 }
 
 export default MapView;


### PR DESCRIPTION
## Summary
- add `MapView.css` with responsive `.map-container`
- use CSS class in `MapView.jsx` instead of inline styles

## Testing
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc3487b2388332908dda6c7bcb66c7