### PR TITLE
Handle loading and error states in ResultsView

### DIFF
--- a/client/src/ResultsView.jsx
+++ b/client/src/ResultsView.jsx
@@ -3,14 +3,25 @@ import { Chart } from 'chart.js/auto'
 
 function ResultsView() {
   const [results, setResults] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
   const canvasRef = useRef(null)
   const chartRef = useRef(null)
 
   useEffect(() => {
+    setLoading(true)
+    setError(null)
     fetch('/data/sample-swmm-result.json')
       .then((res) => res.json())
-      .then((json) => setResults(json))
-      .catch((err) => console.error('Failed to load results', err))
+      .then((json) => {
+        setResults(json)
+        setLoading(false)
+      })
+      .catch((err) => {
+        console.error('Failed to load results', err)
+        setError('Failed to load results')
+        setLoading(false)
+      })
   }, [])
 
   useEffect(() => {
@@ -35,7 +46,9 @@ function ResultsView() {
     return () => chart.destroy()
   }, [results])
 
-  if (!results) return <div>Loading results...</div>
+  if (loading) return <div>Loading results...</div>
+  if (error) return <div className="error-banner">{error}</div>
+  if (!results) return null
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add loading and error state variables to `ResultsView`
- show placeholder during fetch and error message on failure

## Testing
- `npm --prefix client test -- --run`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc436922388332a0b58f093fb8b62b