### PR TITLE
refactor: remove unused chart reference

### DIFF
--- a/client/src/ResultsView.jsx
+++ b/client/src/ResultsView.jsx
@@ -6,7 +6,6 @@ function ResultsView() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const canvasRef = useRef(null)
-  const chartRef = useRef(null)
 
   useEffect(() => {
     setLoading(true)
@@ -42,7 +41,6 @@ function ResultsView() {
       },
     })
 
-    chartRef.current = chart
     return () => chart.destroy()
   }, [results])
 


### PR DESCRIPTION
## Summary
- remove unused chartRef hook from results view
- retain chart destruction via cleanup function

## Testing
- `npm --prefix client test -- --run`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e63a5c083329e326f16189e08b9