### PR TITLE
Improve parse endpoint validation error responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run test:server
       - run: npm --prefix client ci
       - run: npm --prefix client run lint
       - run: npm --prefix client test

--- a/server.js
+++ b/server.js
@@ -31,9 +31,12 @@ app.post('/api/parse', upload.single('file'), (req, res) => {
   try {
     const result = parseInp(req.file.path);
     fs.unlink(req.file.path, () => {});
+    if (!result || Object.keys(result).length === 0) {
+      return res.status(422).json({ error: 'Invalid or empty INP file' });
+    }
     res.json(result);
   } catch (err) {
-    res.status(400).json({ error: 'Parsing failed' });
+    res.status(422).json({ error: `Parsing failed: ${err.message}` });
   }
 });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -15,5 +15,13 @@ describe('POST /api/parse', () => {
   it('returns 400 when no file uploaded', async () => {
     const res = await request(app).post('/api/parse');
     expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No file uploaded');
+  });
+
+  it('returns 422 for invalid INP file', async () => {
+    const file = path.join(__dirname, 'data', 'invalid.inp');
+    const res = await request(app).post('/api/parse').attach('file', file);
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatch(/invalid or empty/i);
   });
 });

--- a/test/data/invalid.inp
+++ b/test/data/invalid.inp
@@ -1,0 +1,1 @@
+This is not a valid INP file


### PR DESCRIPTION
## Summary
- handle empty or invalid uploads in `/api/parse`
- expand API tests for missing or invalid file uploads

## Testing
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68bc917a5e188332b784be98ccd15038