### PR TITLE
Add INP parse upload form

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import MapView from './MapView'
 import ResultsView from './ResultsView'
+import ParseForm from './ParseForm'
 
 function App() {
   const [output, setOutput] = useState('Loading...')
@@ -17,6 +18,7 @@ function App() {
     <div>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
+      <ParseForm />
       <MapView />
       <ResultsView />
     </div>

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+
+function ParseForm() {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const file = e.target.elements.file.files[0]
+    if (!file) return
+
+    const formData = new FormData()
+    formData.append('file', file)
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/parse', {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) throw new Error('Upload failed')
+      const json = await res.json()
+      setData(json)
+    } catch (err) {
+      setError(err.message)
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <h2>Parse INP File</h2>
+      <form onSubmit={handleSubmit}>
+        <input type="file" name="file" />
+        <button type="submit">Upload</button>
+      </form>
+      {loading && <p>Parsing...</p>}
+      {error && <div className="error-banner">{error}</div>}
+      {data && (
+        <pre className="output">{JSON.stringify(data, null, 2)}</pre>
+      )}
+    </div>
+  )
+}
+
+export default ParseForm


### PR DESCRIPTION
## Summary
- add React form to upload INP files to `/api/parse`
- show parsing results as formatted JSON

## Testing
- `npm run test:server`
- `npm --prefix client test -- --run`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc917cd9188332bf68780266f5e202