### PR TITLE
Validate INP file uploads in ParseForm

### DIFF
--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -10,6 +10,12 @@ function ParseForm() {
     const file = e.target.elements.file.files[0]
     if (!file) return
 
+    if (!file.name.toLowerCase().endsWith('.inp')) {
+      setError('Invalid file type. Please upload a .inp file.')
+      setData(null)
+      return
+    }
+
     const formData = new FormData()
     formData.append('file', file)
     setLoading(true)
@@ -34,7 +40,7 @@ function ParseForm() {
     <div>
       <h2>Parse INP File</h2>
       <form onSubmit={handleSubmit}>
-        <input type="file" name="file" />
+        <input type="file" name="file" accept=".inp" />
         <button type="submit">Upload</button>
       </form>
       {loading && <p>Parsing...</p>}


### PR DESCRIPTION
## Summary
- restrict ParseForm upload input to .inp files
- validate selected file extension and display error if invalid

## Testing
- `npm run test:server`
- `npm --prefix client test`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca8aee7bc83328f84c11a82763018