### PR TITLE
Add TWD97 CRS support to MapView

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "chart.js": "^4.5.0",
         "leaflet": "^1.9.4",
+        "proj4": "^2.19.10",
+        "proj4leaflet": "^1.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2208,6 +2210,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2471,6 +2479,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proj4": {
+      "version": "2.19.10",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.10.tgz",
+      "integrity": "sha512-uL6/C6kA8+ncJAEDmUeV8PmNJcTlRLDZZa4/87CzRpb8My4p+Ame4LhC4G3H/77z2icVqcu3nNL9h5buSdnY+g==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
+    },
+    "node_modules/proj4leaflet": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.2.tgz",
+      "integrity": "sha512-6GdDeUlhX/tHUiMEj80xQhlPjwrXcdfD0D5OBymY8WvxfbmZcdhNqQk7n7nFf53ue6QdP9ls9ZPjsAxnbZDTsw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "proj4": "^2.3.14"
       }
     },
     "node_modules/punycode": {
@@ -3145,6 +3175,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
+      "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "chart.js": "^4.5.0",
     "leaflet": "^1.9.4",
+    "proj4": "^2.19.10",
+    "proj4leaflet": "^1.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -1,23 +1,30 @@
-import { useRef, useEffect } from 'react';
+import { useEffect } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import proj4 from 'proj4';
+import 'proj4leaflet';
 import './MapView.css';
 
 function MapView() {
-  const mapRef = useRef(null);
-
   useEffect(() => {
-    if (!mapRef.current) return;
-    const map = L.map(mapRef.current).setView([51.505, -0.09], 13);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; OpenStreetMap contributors',
-    }).addTo(map);
+    window.proj4 = proj4;
+    const twd97 = new L.Proj.CRS(
+      'EPSG:3826',
+      '+proj=tmerc +lat_0=0 +lon_0=121 +k=0.9999 +x_0=250000 +y_0=0 +ellps=GRS80 +units=m +no_defs'
+    );
+
+    const map = L.map('map', {
+      crs: twd97,
+      center: [23.5, 121],
+      zoom: 7,
+    });
+
     return () => {
       map.remove();
     };
   }, []);
 
-  return <div ref={mapRef} className="map-container" />;
+  return <div id="map" className="map-container" />;
 }
 
 export default MapView;

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -1,19 +1,18 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
-const mapInstance = {
-  setView: vi.fn().mockReturnThis(),
-  remove: vi.fn(),
-};
-const tileLayerInstance = { addTo: vi.fn() };
+const mapInstance = { remove: vi.fn() };
+
+vi.mock('proj4leaflet', () => ({}));
 
 vi.mock('leaflet', () => ({
   default: {
     map: vi.fn((el) => {
-      el.classList.add('leaflet-container');
+      const element = typeof el === 'string' ? document.getElementById(el) : el;
+      if (element) element.classList.add('leaflet-container');
       return mapInstance;
     }),
-    tileLayer: vi.fn(() => tileLayerInstance),
+    Proj: { CRS: vi.fn() },
   },
 }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "proj4": "^2.19.10",
+        "proj4leaflet": "^1.0.2"
       },
       "devDependencies": {
         "supertest": "^6.3.3",
@@ -1838,6 +1840,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -2246,6 +2254,28 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/proj4": {
+      "version": "2.19.10",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.19.10.tgz",
+      "integrity": "sha512-uL6/C6kA8+ncJAEDmUeV8PmNJcTlRLDZZa4/87CzRpb8My4p+Ame4LhC4G3H/77z2icVqcu3nNL9h5buSdnY+g==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
+    },
+    "node_modules/proj4leaflet": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.2.tgz",
+      "integrity": "sha512-6GdDeUlhX/tHUiMEj80xQhlPjwrXcdfD0D5OBymY8WvxfbmZcdhNqQk7n7nFf53ue6QdP9ls9ZPjsAxnbZDTsw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "proj4": "^2.3.14"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -2995,6 +3025,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
+      "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "proj4": "^2.19.10",
+    "proj4leaflet": "^1.0.2"
   },
   "devDependencies": {
     "supertest": "^6.3.3",


### PR DESCRIPTION
## Summary
- install proj4 and proj4leaflet projection libraries
- use TWD97 (EPSG:3826) CRS and initialize map with projected center
- update unit tests for new map initialization

## Testing
- `npm run test:server`
- `npm --prefix client test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bd17e1116c83329b2487b57a1b1ca1