### PR TITLE
feat: update map markers on coordinate changes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import ParseForm from './ParseForm'
 
 function App() {
   const [output, setOutput] = useState('Loading...')
+  const [coordinates, setCoordinates] = useState([])
 
   useEffect(() => {
     fetch('/api/output')
@@ -18,8 +19,8 @@ function App() {
     <div>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
-      <ParseForm />
-      <MapView />
+      <ParseForm setCoordinates={setCoordinates} />
+      <MapView coordinates={coordinates} />
       <ResultsView />
     </div>
   )

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -1,54 +1,64 @@
-import { useEffect } from 'react';
-import L from 'leaflet';
-import proj4 from 'proj4';
-import 'leaflet/dist/leaflet.css';
-import './MapView.css';
+import { useEffect, useRef } from 'react'
+import L from 'leaflet'
+import proj4 from 'proj4'
+import 'leaflet/dist/leaflet.css'
+import './MapView.css'
 
 const EPSG3826 =
   "+proj=tmerc +lat_0=0 +lon_0=121 +k=0.9999 +x_0=250000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs"
-proj4.defs('EPSG:3826', EPSG3826);
+proj4.defs('EPSG:3826', EPSG3826)
 
 function MapView({ coordinates = [] }) {
+  const mapRef = useRef(null)
+  const layerRef = useRef(null)
+
   useEffect(() => {
-    const map = L.map('map').setView([23, 121], 9);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; OpenStreetMap contributors',
-    }).addTo(map);
+    if (!mapRef.current) {
+      mapRef.current = L.map('map').setView([23, 121], 9)
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors',
+      }).addTo(mapRef.current)
+      layerRef.current = L.layerGroup().addTo(mapRef.current)
+    }
 
-    const markers = [];
-    let latlngs = []; // Ensure latlngs is defined here
-
+    layerRef.current.clearLayers()
+    const latlngs = []
     coordinates.forEach((xy) => {
       try {
-        const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', xy);
+        const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', xy)
         if (isFinite(lat) && isFinite(lon)) {
-          const marker = L.marker([lat, lon]).addTo(map);
-          markers.push(marker);
-          latlngs.push([lat, lon]); // This should now work without error
+          L.marker([lat, lon]).addTo(layerRef.current)
+          latlngs.push([lat, lon])
         } else {
-          console.error('Invalid projected coordinates:', lat, lon);
+          console.error('Invalid projected coordinates:', lat, lon)
         }
       } catch (error) {
-        console.error('Error projecting coordinates:', error);
+        console.error('Error projecting coordinates:', error)
       }
-    });
+    })
 
     if (latlngs.length > 0) {
       try {
-        map.fitBounds(latlngs);
+        mapRef.current.fitBounds(latlngs)
       } catch (error) {
-        console.error('Error fitting bounds:', error);
+        console.error('Error fitting bounds:', error)
       }
     } else {
-      map.setView([23, 121], 9); // Default view
+      mapRef.current.setView([23, 121], 9)
     }
+  }, [coordinates])
 
+  useEffect(() => {
     return () => {
-      map.remove();
-    };
-  }, [coordinates]);
+      if (mapRef.current) {
+        mapRef.current.remove()
+        mapRef.current = null
+        layerRef.current = null
+      }
+    }
+  }, [])
 
-  return <div id="map" className="map-container" />;
+  return <div id="map" className="map-container" />
 }
 
-export default MapView;
+export default MapView

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -23,9 +23,9 @@ function MapView({ coordinates = [] }) {
 
     layerRef.current.clearLayers()
     const latlngs = []
-    coordinates.forEach((xy) => {
+    coordinates.forEach(([id, x, y]) => {
       try {
-        const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', xy)
+        const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', [x, y])
         if (isFinite(lat) && isFinite(lon)) {
           L.marker([lat, lon]).addTo(layerRef.current)
           latlngs.push([lat, lon])

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -23,11 +23,11 @@ function MapView({ coordinates = [] }) {
 
     layerRef.current.clearLayers()
     const latlngs = []
-    coordinates.forEach(([id, x, y]) => {
+    coordinates.forEach(([node_id, x, y]) => {
       try {
         const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', [x, y])
         if (isFinite(lat) && isFinite(lon)) {
-          L.marker([lat, lon]).addTo(layerRef.current)
+          L.marker([lat, lon], {"title": node_id}).addTo(layerRef.current)
           latlngs.push([lat, lon])
         } else {
           console.error('Invalid projected coordinates:', lat, lon)

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -1,12 +1,14 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 const mapInstance = {
   setView: vi.fn().mockReturnThis(),
+  fitBounds: vi.fn().mockReturnThis(),
   remove: vi.fn(),
 };
 const tileLayerInstance = { addTo: vi.fn() };
-const markerInstance = { addTo: vi.fn().mockReturnThis(), getLatLng: vi.fn(() => ({ lat: 0, lng: 0 })) };
+const markerInstance = { addTo: vi.fn().mockReturnThis() };
+const layerGroupInstance = { addTo: vi.fn().mockReturnThis(), clearLayers: vi.fn() };
 
 vi.mock('leaflet', () => ({
   default: {
@@ -17,6 +19,7 @@ vi.mock('leaflet', () => ({
     }),
     tileLayer: vi.fn(() => tileLayerInstance),
     marker: vi.fn(() => markerInstance),
+    layerGroup: vi.fn(() => layerGroupInstance),
   },
 }));
 
@@ -30,11 +33,13 @@ import L from 'leaflet';
 import proj4 from 'proj4';
 
 describe('MapView', () => {
-  it('creates markers for coordinates and cleans up on unmount', () => {
+  it('creates markers for coordinates and cleans up on unmount', async () => {
     const coords = [[250000, 0]];
     const { container, unmount } = render(<MapView coordinates={coords} />);
     expect(container.querySelector('.leaflet-container')).toBeInTheDocument();
-    expect(proj4).toHaveBeenCalledWith('EPSG:3826', 'EPSG:4326', [250000, 0]);
+    await waitFor(() =>
+      expect(proj4).toHaveBeenCalledWith('EPSG:3826', 'EPSG:4326', [250000, 0])
+    );
     expect(L.marker).toHaveBeenCalledWith([24, 121]);
     unmount();
     expect(mapInstance.remove).toHaveBeenCalled();

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -40,7 +40,7 @@ describe('MapView', () => {
     await waitFor(() =>
       expect(proj4).toHaveBeenCalledWith('EPSG:3826', 'EPSG:4326', [250000, 0])
     );
-    expect(L.marker).toHaveBeenCalledWith([24, 121]);
+    expect(L.marker).toHaveBeenCalledWith([24, 121], {'title': 'foo'});
     unmount();
     expect(mapInstance.remove).toHaveBeenCalled();
   });

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -34,7 +34,7 @@ import proj4 from 'proj4';
 
 describe('MapView', () => {
   it('creates markers for coordinates and cleans up on unmount', async () => {
-    const coords = [[250000, 0]];
+    const coords = [['foo', 250000, 0]];
     const { container, unmount } = render(<MapView coordinates={coords} />);
     expect(container.querySelector('.leaflet-container')).toBeInTheDocument();
     await waitFor(() =>

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -28,8 +28,12 @@ function ParseForm({ setCoordinates }) {
       if (!res.ok) throw new Error('Upload failed')
       const json = await res.json()
       setData(json)
-      if (json?.coordinates) {
-        setCoordinates(json.coordinates)
+      if (json?.COORDINATES) {
+        const coordinates = json.COORDINATES.map(([first, ...rest]) => [
+          first,
+          ...rest.map(Number)
+        ]);
+        setCoordinates(coordinates)
       }
     } catch (err) {
       setError(err.message)

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-function ParseForm() {
+function ParseForm({ setCoordinates }) {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -28,6 +28,9 @@ function ParseForm() {
       if (!res.ok) throw new Error('Upload failed')
       const json = await res.json()
       setData(json)
+      if (json?.coordinates) {
+        setCoordinates(json.coordinates)
+      }
     } catch (err) {
       setError(err.message)
       setData(null)


### PR DESCRIPTION
## Summary
- keep parsed coordinates in state and pass them to `MapView`
- update `MapView` markers via a LayerGroup whenever coordinates change
- adjust tests for new map update behavior

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c1186ab4908332bcad6613950351a7