### PR TITLE
Add coordinate validation and tests

### DIFF
--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -32,8 +32,22 @@ function ParseForm({ setCoordinates }) {
         const coordinates = json.COORDINATES.map(([first, ...rest]) => [
           first,
           ...rest.map(Number)
-        ]);
-        setCoordinates(coordinates)
+        ])
+        const valid = Array.isArray(coordinates) &&
+          coordinates.every(
+            (arr) => arr.length >= 3 && arr.slice(1).every((n) => isFinite(n))
+          )
+        if (valid) {
+          setCoordinates(coordinates)
+        } else {
+          setCoordinates([])
+          setData(null)
+          setError('Invalid coordinates in file.')
+        }
+      } else {
+        setCoordinates([])
+        setData(null)
+        setError('Coordinates not found in file.')
       }
     } catch (err) {
       setError(err.message)

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -5,7 +5,7 @@ import ParseForm from './ParseForm'
 describe('ParseForm', () => {
   it('shows error when coordinates are missing', async () => {
     const setCoordinates = vi.fn()
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({})
     })
@@ -22,7 +22,7 @@ describe('ParseForm', () => {
 
   it('shows error when coordinates are invalid', async () => {
     const setCoordinates = vi.fn()
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ COORDINATES: [['id', 'foo', '0']] })
     })

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -1,0 +1,39 @@
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ParseForm from './ParseForm'
+
+describe('ParseForm', () => {
+  it('shows error when coordinates are missing', async () => {
+    const setCoordinates = vi.fn()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    })
+    const { container, findByText } = render(
+      <ParseForm setCoordinates={setCoordinates} />
+    )
+    const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const input = container.querySelector('input[type="file"]')
+    fireEvent.change(input, { target: { files: [file] } })
+    fireEvent.submit(container.querySelector('form'))
+    await findByText('Coordinates not found in file.')
+    expect(setCoordinates).toHaveBeenCalledWith([])
+  })
+
+  it('shows error when coordinates are invalid', async () => {
+    const setCoordinates = vi.fn()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ COORDINATES: [['id', 'foo', '0']] })
+    })
+    const { container, findByText } = render(
+      <ParseForm setCoordinates={setCoordinates} />
+    )
+    const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const input = container.querySelector('input[type="file"]')
+    fireEvent.change(input, { target: { files: [file] } })
+    fireEvent.submit(container.querySelector('form'))
+    await findByText('Invalid coordinates in file.')
+    expect(setCoordinates).toHaveBeenCalledWith([])
+  })
+})


### PR DESCRIPTION
## Summary
- validate parsed coordinates in ParseForm and show error when missing or invalid
- test ParseForm handling of missing or invalid coordinates

## Testing
- `npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68c1224017f48332a4e8106fb926c2ec