### PR TITLE
feat(map): fit bounds on coordinate change

### DIFF
--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -11,6 +11,7 @@ proj4.defs('EPSG:3826', EPSG3826)
 function MapView({ coordinates = [] }) {
   const mapRef = useRef(null)
   const layerRef = useRef(null)
+  const boundsRef = useRef(null)
 
   useEffect(() => {
     if (!mapRef.current) {
@@ -27,7 +28,7 @@ function MapView({ coordinates = [] }) {
       try {
         const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', [x, y])
         if (isFinite(lat) && isFinite(lon)) {
-          L.marker([lat, lon], {"title": node_id}).addTo(layerRef.current)
+          L.marker([lat, lon], { title: node_id }).addTo(layerRef.current)
           latlngs.push([lat, lon])
         } else {
           console.error('Invalid projected coordinates:', lat, lon)
@@ -37,13 +38,18 @@ function MapView({ coordinates = [] }) {
       }
     })
 
-    if (latlngs.length > 0) {
-      try {
-        mapRef.current.fitBounds(latlngs)
-      } catch (error) {
-        console.error('Error fitting bounds:', error)
+    const newBounds = L.latLngBounds(latlngs)
+    if (newBounds.isValid()) {
+      if (!boundsRef.current || !boundsRef.current.equals(newBounds)) {
+        try {
+          mapRef.current.fitBounds(newBounds)
+          boundsRef.current = newBounds
+        } catch (error) {
+          console.error('Error fitting bounds:', error)
+        }
       }
     } else {
+      boundsRef.current = null
       mapRef.current.setView([23, 121], 9)
     }
   }, [coordinates])

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -1,5 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { latLngBounds } = vi.hoisted(() => ({ latLngBounds: vi.fn() }));
 
 const mapInstance = {
   setView: vi.fn().mockReturnThis(),
@@ -20,6 +22,7 @@ vi.mock('leaflet', () => ({
     tileLayer: vi.fn(() => tileLayerInstance),
     marker: vi.fn(() => markerInstance),
     layerGroup: vi.fn(() => layerGroupInstance),
+    latLngBounds,
   },
 }));
 
@@ -33,6 +36,14 @@ import L from 'leaflet';
 import proj4 from 'proj4';
 
 describe('MapView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    latLngBounds.mockImplementation(() => ({
+      isValid: () => true,
+      equals: vi.fn(() => false),
+    }));
+  });
+
   it('creates markers for coordinates and cleans up on unmount', async () => {
     const coords = [['foo', 250000, 0]];
     const { container, unmount } = render(<MapView coordinates={coords} />);
@@ -43,5 +54,20 @@ describe('MapView', () => {
     expect(L.marker).toHaveBeenCalledWith([24, 121], {'title': 'foo'});
     unmount();
     expect(mapInstance.remove).toHaveBeenCalled();
+  });
+
+  it('fits bounds when coordinates update', async () => {
+    const invalidBounds = { isValid: () => false, equals: vi.fn() };
+    const validBounds = { isValid: () => true, equals: vi.fn(() => false) };
+    latLngBounds
+      .mockImplementationOnce(() => invalidBounds)
+      .mockImplementationOnce(() => validBounds);
+
+    const { rerender } = render(<MapView coordinates={[]} />);
+    rerender(<MapView coordinates={[['foo', 250000, 0]]} />);
+
+    await waitFor(() =>
+      expect(mapInstance.fitBounds).toHaveBeenCalledWith(validBounds)
+    );
   });
 });


### PR DESCRIPTION
## Summary
- track previous map bounds and compute new bounds from coordinates
- fit map view only when bounds change
- test that fitBounds is invoked after coordinate updates

## Testing
- `npm --prefix client test -- --run`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c1223e7a5483328d2909f551da9ce7