### PR TITLE
Add Node.js and Mongo devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "SWMM-GUI Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [3000, 27017],
+  "portsAttributes": {
+    "3000": {
+      "label": "Web"
+    },
+    "27017": {
+      "label": "MongoDB"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "mongodb.mongodb-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/javascript-node:20
+    command: sleep infinity
+    volumes:
+      - ..:/workspace:cached
+    ports:
+      - 3000:3000
+    networks:
+      - dev
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:6
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - 27017:27017
+    networks:
+      - dev
+networks:
+  dev:
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- add VS Code devcontainer with Node.js and MongoDB services for local development

## Testing
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c727263ec88332aff64c90f6f154f5