### PR TITLE
feat: add theme toggle

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -9,8 +9,8 @@ h1 {
 }
 
 .output {
-  background-color: #f8f8f8;
-  border: 1px solid #ccc;
+  background-color: var(--output-bg);
+  border: 1px solid var(--output-border);
   padding: 1rem;
   text-align: left;
   white-space: pre-wrap;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,11 @@ import ParseForm from './ParseForm'
 function App() {
   const [output, setOutput] = useState('Loading...')
   const [coordinates, setCoordinates] = useState([])
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
 
   useEffect(() => {
     fetch('/api/output')
@@ -15,8 +20,15 @@ function App() {
       .catch((err) => setOutput(`Error: ${err.message}`))
   }, [])
 
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
   return (
     <div>
+      <button onClick={toggleTheme}>
+        Switch to {theme === 'light' ? 'Dark' : 'Light'} Mode
+      </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
       <ParseForm setCoordinates={setCoordinates} />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,9 +3,14 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
+  color-scheme: light;
+  --link-color: #646cff;
+  --link-hover: #747bff;
+  --button-bg: #f9f9f9;
+  --output-bg: #f8f8f8;
+  --output-border: #ccc;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,13 +18,23 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+:root[data-theme='dark'] {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+  color-scheme: dark;
+  --link-hover: #535bf2;
+  --button-bg: #1a1a1a;
+  --output-bg: #1a1a1a;
+  --output-border: #555;
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--link-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--link-hover);
 }
 
 body {
@@ -42,7 +57,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--button-bg);
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -52,17 +67,4 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- add button to switch between light and dark modes
- style components with CSS variables for theme colors
- default UI to light mode

## Testing
- `npm --prefix client test -- --run`
- `npm run test:server`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c72ed27ad48332b908c534a2310c37