### PR TITLE
feat: add accessible theme toggle

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,12 +29,6 @@ function App() {
       <button
         className="theme-toggle"
         onClick={toggleTheme}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            toggleTheme()
-          }
-        }}
         aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
         role="switch"
         aria-checked={theme === 'dark'}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,8 +26,20 @@ function App() {
 
   return (
     <div>
-      <button onClick={toggleTheme}>
-        Switch to {theme === 'light' ? 'Dark' : 'Light'} Mode
+      <button
+        className="theme-toggle"
+        onClick={toggleTheme}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            toggleTheme()
+          }
+        }}
+        aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+        role="switch"
+        aria-checked={theme === 'dark'}
+      >
+        {theme === 'light' ? '🌞' : '🌜'}
       </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -62,9 +62,25 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--link-hover);
 }
+
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid var(--link-hover);
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.5rem;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  color: var(--link-hover);
+  outline: 2px solid var(--link-hover);
+  border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- replace text button with icon-based theme toggle using sun and moon emojis
- support keyboard and screen readers with aria attributes
- add theme-aware hover and focus styles

## Testing
- `npm --prefix client run lint`
- `npm --prefix client test`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c7339cc2748332bc57e497c908f869