### PR TITLE
feat: structure inp parser output

### DIFF
--- a/server/inpParser.js
+++ b/server/inpParser.js
@@ -19,10 +19,11 @@ function parseInp(filePath) {
     COORDINATES: (t) => ({ id: t[0], x: parseFloat(t[1]), y: parseFloat(t[2]) }),
     JUNCTIONS: (t) => ({
       id: t[0],
-      elev: parseFloat(t[1]),
-      depth: parseFloat(t[2]),
-      surDepth: parseFloat(t[3]),
-      apond: parseFloat(t[4]),
+      elevation: parseFloat(t[1]),
+      maxDepth: parseFloat(t[2]),
+      initDepth: parseFloat(t[3]),
+      surDepth: parseFloat(t[4]),
+      aponded: parseFloat(t[5]),
     }),
     CONDUITS: (t) => ({
       id: t[0],

--- a/server/inpParser.js
+++ b/server/inpParser.js
@@ -15,6 +15,28 @@ function parseInp(filePath) {
   const sections = {};
   let currentSection = null;
 
+  const converters = {
+    COORDINATES: (t) => ({ id: t[0], x: parseFloat(t[1]), y: parseFloat(t[2]) }),
+    JUNCTIONS: (t) => ({
+      id: t[0],
+      elev: parseFloat(t[1]),
+      depth: parseFloat(t[2]),
+      surDepth: parseFloat(t[3]),
+      apond: parseFloat(t[4]),
+    }),
+    CONDUITS: (t) => ({
+      id: t[0],
+      from: t[1],
+      to: t[2],
+      length: parseFloat(t[3]),
+      roughness: parseFloat(t[4]),
+      inOffset: parseFloat(t[5]),
+      outOffset: parseFloat(t[6]),
+      initFlow: parseFloat(t[7]),
+      maxFlow: parseFloat(t[8]),
+    }),
+  };
+
   for (const rawLine of lines) {
     const line = trimComments(rawLine);
     if (!line) continue;
@@ -27,7 +49,9 @@ function parseInp(filePath) {
       continue;
     }
     if (currentSection) {
-      sections[currentSection].push(tokenize(line));
+      const tokens = tokenize(line);
+      const convert = converters[currentSection];
+      sections[currentSection].push(convert ? convert(tokens) : tokens);
     }
   }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -14,7 +14,7 @@ describe('POST /api/parse', () => {
     const res = await request(app).post('/api/parse').attach('file', file);
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('JUNCTIONS');
-    expect(res.body.JUNCTIONS[0][0]).toBe('J1');
+    expect(res.body.JUNCTIONS[0].id).toBe('J1');
     expect(insertOne).toHaveBeenCalled();
   });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -14,7 +14,7 @@ describe('POST /api/parse', () => {
     const res = await request(app).post('/api/parse').attach('file', file);
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('JUNCTIONS');
-    expect(res.body.JUNCTIONS[0].id).toBe('J1');
+    expect(res.body.JUNCTIONS[0]).toMatchObject({ id: 'J1', elevation: 0 });
     expect(insertOne).toHaveBeenCalled();
   });
 

--- a/test/data/sample.inp
+++ b/test/data/sample.inp
@@ -1,7 +1,7 @@
 [JUNCTIONS]
-;ID     Elev  Depth  SurDepth  Apond
-J1      0     0      0         0
-J2      0     0      0         0
+;ID     Elevation  MaxDepth  InitDepth  SurDepth  Aponded
+J1      0          0         0          0         0
+J2      0          0         0          0         0
 
 [CONDUITS]
 ;ID     From   To     Length  Roughness  InOffset  OutOffset  InitFlow  MaxFlow

--- a/test/inpParser.test.js
+++ b/test/inpParser.test.js
@@ -11,8 +11,15 @@ describe('parseInp', () => {
     expect(result).toHaveProperty('JUNCTIONS');
     expect(result).toHaveProperty('CONDUITS');
     expect(result).toHaveProperty('COORDINATES');
-    expect(result.JUNCTIONS[0].id).toBe('J1');
-    expect(result.CONDUITS[0].from).toBe('J1');
-    expect(result.COORDINATES[0]).toMatchObject({ id: 'J1', x: 100, y: 100 });
+    expect(result.JUNCTIONS[0]).toEqual({
+      id: 'J1',
+      elevation: 0,
+      maxDepth: 0,
+      initDepth: 0,
+      surDepth: 0,
+      aponded: 0,
+    });
+    expect(result.CONDUITS[0]).toMatchObject({ id: 'C1', from: 'J1', to: 'J2' });
+    expect(result.COORDINATES[0]).toEqual({ id: 'J1', x: 100, y: 100 });
   });
 });

--- a/test/inpParser.test.js
+++ b/test/inpParser.test.js
@@ -11,8 +11,8 @@ describe('parseInp', () => {
     expect(result).toHaveProperty('JUNCTIONS');
     expect(result).toHaveProperty('CONDUITS');
     expect(result).toHaveProperty('COORDINATES');
-    expect(result.JUNCTIONS[0][0]).toBe('J1');
-    expect(result.CONDUITS[0][1]).toBe('J1');
-    expect(result.COORDINATES.length).toBe(2);
+    expect(result.JUNCTIONS[0].id).toBe('J1');
+    expect(result.CONDUITS[0].from).toBe('J1');
+    expect(result.COORDINATES[0]).toMatchObject({ id: 'J1', x: 100, y: 100 });
   });
 });


### PR DESCRIPTION
## Summary
- parse INP sections into structured objects for coordinates, junctions and conduits
- update parser and API tests to expect object fields

## Testing
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c7a2c90c808332a7156c04b3660221