### PR TITLE
fix: validate uploaded coordinates

### DIFF
--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -40,11 +40,13 @@ function MapView({ coordinates = [] }) {
 
     const newBounds = L.latLngBounds(latlngs)
     if (newBounds.isValid()) {
-      try {
-        mapRef.current.fitBounds(newBounds)
-        boundsRef.current = newBounds
-      } catch (error) {
-        console.error('Error fitting bounds:', error)
+      if (!boundsRef.current || !boundsRef.current.equals(newBounds)) {
+        try {
+          mapRef.current.fitBounds(newBounds)
+          boundsRef.current = newBounds
+        } catch (error) {
+          console.error('Error fitting bounds:', error)
+        }
       }
     } else {
       boundsRef.current = null

--- a/client/src/MapView.jsx
+++ b/client/src/MapView.jsx
@@ -24,11 +24,11 @@ function MapView({ coordinates = [] }) {
 
     layerRef.current.clearLayers()
     const latlngs = []
-    coordinates.forEach(([node_id, x, y]) => {
+    coordinates.forEach(({ id, x, y }) => {
       try {
         const [lon, lat] = proj4('EPSG:3826', 'EPSG:4326', [x, y])
         if (isFinite(lat) && isFinite(lon)) {
-          L.marker([lat, lon], { title: node_id }).addTo(layerRef.current)
+          L.marker([lat, lon], { title: id }).addTo(layerRef.current)
           latlngs.push([lat, lon])
         } else {
           console.error('Invalid projected coordinates:', lat, lon)
@@ -40,13 +40,11 @@ function MapView({ coordinates = [] }) {
 
     const newBounds = L.latLngBounds(latlngs)
     if (newBounds.isValid()) {
-      if (!boundsRef.current || !boundsRef.current.equals(newBounds)) {
-        try {
-          mapRef.current.fitBounds(newBounds)
-          boundsRef.current = newBounds
-        } catch (error) {
-          console.error('Error fitting bounds:', error)
-        }
+      try {
+        mapRef.current.fitBounds(newBounds)
+        boundsRef.current = newBounds
+      } catch (error) {
+        console.error('Error fitting bounds:', error)
       }
     } else {
       boundsRef.current = null

--- a/client/src/MapView.test.jsx
+++ b/client/src/MapView.test.jsx
@@ -38,33 +38,30 @@ import proj4 from 'proj4';
 describe('MapView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    latLngBounds.mockImplementation(() => ({
-      isValid: () => true,
-      equals: vi.fn(() => false),
-    }));
+    latLngBounds.mockImplementation(() => ({ isValid: () => true }));
   });
 
   it('creates markers for coordinates and cleans up on unmount', async () => {
-    const coords = [['foo', 250000, 0]];
+    const coords = [{ id: 'foo', x: 250000, y: 0 }];
     const { container, unmount } = render(<MapView coordinates={coords} />);
     expect(container.querySelector('.leaflet-container')).toBeInTheDocument();
     await waitFor(() =>
       expect(proj4).toHaveBeenCalledWith('EPSG:3826', 'EPSG:4326', [250000, 0])
     );
-    expect(L.marker).toHaveBeenCalledWith([24, 121], {'title': 'foo'});
+    expect(L.marker).toHaveBeenCalledWith([24, 121], { title: 'foo' });
     unmount();
     expect(mapInstance.remove).toHaveBeenCalled();
   });
 
   it('fits bounds when coordinates update', async () => {
-    const invalidBounds = { isValid: () => false, equals: vi.fn() };
-    const validBounds = { isValid: () => true, equals: vi.fn(() => false) };
+    const invalidBounds = { isValid: () => false };
+    const validBounds = { isValid: () => true };
     latLngBounds
       .mockImplementationOnce(() => invalidBounds)
       .mockImplementationOnce(() => validBounds);
 
     const { rerender } = render(<MapView coordinates={[]} />);
-    rerender(<MapView coordinates={[['foo', 250000, 0]]} />);
+    rerender(<MapView coordinates={[{ id: 'foo', x: 250000, y: 0 }]} />);
 
     await waitFor(() =>
       expect(mapInstance.fitBounds).toHaveBeenCalledWith(validBounds)

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,5 +1,24 @@
 import { useState } from 'react'
 
+const normalizeCoordinates = (coordinates) => {
+  if (!Array.isArray(coordinates)) return null
+
+  const normalized = []
+  for (const coord of coordinates) {
+    if (!coord || typeof coord !== 'object') return null
+    const { id, x, y } = coord
+    if (id === undefined || x === undefined || y === undefined) return null
+
+    const xNum = Number(x)
+    const yNum = Number(y)
+    if (!Number.isFinite(xNum) || !Number.isFinite(yNum)) return null
+
+    normalized.push({ id: String(id), x: xNum, y: yNum })
+  }
+
+  return normalized
+}
+
 function ParseForm({ setCoordinates }) {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
@@ -26,29 +45,18 @@ function ParseForm({ setCoordinates }) {
         body: formData,
       })
       if (!res.ok) throw new Error('Upload failed')
-      const json = await res.json()
-      setData(json)
-      if (json?.COORDINATES) {
-        const coordinates = json.COORDINATES.map(([first, ...rest]) => [
-          first,
-          ...rest.map(Number)
-        ])
-        const valid = Array.isArray(coordinates) &&
-          coordinates.every(
-            (arr) => arr.length >= 3 && arr.slice(1).every((n) => isFinite(n))
-          )
-        if (valid) {
-          setCoordinates(coordinates)
-        } else {
-          setCoordinates([])
-          setData(null)
-          setError('Invalid coordinates in file.')
-        }
-      } else {
+      const result = await res.json()
+      setData(result)
+
+      const normalized = normalizeCoordinates(result.coordinates)
+      if (!normalized) {
         setCoordinates([])
         setData(null)
-        setError('Coordinates not found in file.')
+        setError('Invalid coordinates data received from server.')
+        return
       }
+
+      setCoordinates(normalized)
     } catch (err) {
       setError(err.message)
       setData(null)

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -5,7 +5,7 @@ const normalizeCoordinates = (coordinates) => {
 
   const normalized = []
   for (const coord of coordinates) {
-    if (!coord || typeof coord !== 'object') return null
+    if (!coord || typeof coord !== 'object' || Array.isArray(coord)) return null
     const { id, x, y } = coord
     if (id === undefined || x === undefined || y === undefined) return null
 

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -1,39 +1,40 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import ParseForm from './ParseForm'
 
 describe('ParseForm', () => {
-  it('shows error when coordinates are missing', async () => {
+  it('passes valid coordinates from parser to setCoordinates', async () => {
+    const setCoordinates = vi.fn()
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ coordinates: [{ id: 'n1', x: '1', y: 2 }] })
+    })
+    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const input = container.querySelector('input[type="file"]')
+    fireEvent.change(input, { target: { files: [file] } })
+    fireEvent.submit(container.querySelector('form'))
+    await waitFor(() =>
+      expect(setCoordinates).toHaveBeenCalledWith([{ id: 'n1', x: 1, y: 2 }])
+    )
+  })
+
+  it('shows an error when coordinates are missing or invalid', async () => {
     const setCoordinates = vi.fn()
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({})
     })
-    const { container, findByText } = render(
-      <ParseForm setCoordinates={setCoordinates} />
-    )
+    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
     fireEvent.submit(container.querySelector('form'))
-    await findByText('Coordinates not found in file.')
-    expect(setCoordinates).toHaveBeenCalledWith([])
-  })
-
-  it('shows error when coordinates are invalid', async () => {
-    const setCoordinates = vi.fn()
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ COORDINATES: [['id', 'foo', '0']] })
-    })
-    const { container, findByText } = render(
-      <ParseForm setCoordinates={setCoordinates} />
+    await waitFor(() => expect(setCoordinates).toHaveBeenCalledWith([]))
+    await waitFor(() =>
+      expect(
+        container.querySelector('.error-banner')?.textContent
+      ).toContain('Invalid coordinates data received from server.')
     )
-    const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
-    const input = container.querySelector('input[type="file"]')
-    fireEvent.change(input, { target: { files: [file] } })
-    fireEvent.submit(container.querySelector('form'))
-    await findByText('Invalid coordinates in file.')
-    expect(setCoordinates).toHaveBeenCalledWith([])
   })
 })


### PR DESCRIPTION
## Summary
- normalize uploaded coordinate data before forwarding to the map
- surface an error and avoid map updates when the parser returns malformed coordinates

## Testing
- `npm --prefix client test -- --run`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c7a2d8b7e483329cf193b9301f1c3e