### PR TITLE
feat: show stored inp files

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -8,6 +8,11 @@ h1 {
   text-align: center;
 }
 
+.inp-files-button {
+  display: block;
+  margin: 1rem auto;
+}
+
 .output {
   background-color: var(--output-bg);
   border: 1px solid var(--output-border);
@@ -17,4 +22,81 @@ h1 {
   font-family: monospace;
   max-height: 70vh;
   overflow: auto;
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--backdrop-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--modal-bg);
+  color: inherit;
+  width: min(600px, 100%);
+  max-height: 90vh;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--output-border);
+}
+
+.modal-body {
+  padding: 1rem 1.5rem;
+  overflow-y: auto;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+}
+
+.modal-close:hover,
+.modal-close:focus {
+  color: var(--link-hover);
+}
+
+.modal-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.modal-table th,
+.modal-table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--output-border);
+  text-align: left;
+}
+
+.modal-table th {
+  background-color: var(--table-header-bg);
+}
+
+.error-banner {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background-color: var(--error-bg);
+  border: 1px solid var(--error-border);
+  color: var(--error-text);
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,11 +3,13 @@ import './App.css'
 import MapView from './MapView'
 import ResultsView from './ResultsView'
 import ParseForm from './ParseForm'
+import InpFilesModal from './InpFilesModal'
 
 function App() {
   const [output, setOutput] = useState('Loading...')
   const [coordinates, setCoordinates] = useState([])
   const [theme, setTheme] = useState('light')
+  const [showInpFilesModal, setShowInpFilesModal] = useState(false)
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
@@ -35,11 +37,21 @@ function App() {
       >
         {theme === 'light' ? '🌞' : '🌜'}
       </button>
+      <button
+        className="inp-files-button"
+        type="button"
+        onClick={() => setShowInpFilesModal(true)}
+      >
+        View Stored INP Files
+      </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
       <ParseForm setCoordinates={setCoordinates} />
       <MapView coordinates={coordinates} />
       <ResultsView />
+      {showInpFilesModal && (
+        <InpFilesModal onClose={() => setShowInpFilesModal(false)} />
+      )}
     </div>
   )
 }

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -61,10 +61,11 @@ function InpFilesModal({ onClose }) {
           </button>
         </div>
         <div className="modal-body">
-          {loading && <p>Loading INP files...</p>}
-          {error && <div className="error-banner">{error}</div>}
-          {!loading && !error && files.length === 0 && <p>No INP files have been stored yet.</p>}
-          {!loading && !error && files.length > 0 && (
+          {loading ? (
+            <p>Loading INP files...</p>
+          ) : error ? (
+            <div className="error-banner">{error}</div>
+          ) : files.length > 0 ? (
             <table className="modal-table">
               <thead>
                 <tr>
@@ -74,13 +75,15 @@ function InpFilesModal({ onClose }) {
               </thead>
               <tbody>
                 {files.map((file) => (
-                  <tr key={file._id || `${file.filename}-${file.uploadedAt}`}>
+                  <tr key={file._id}>
                     <td>{file.filename || 'Unnamed file'}</td>
                     <td>{formatDate(file.uploadedAt)}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
+          ) : (
+            <p>No INP files have been stored yet.</p>
           )}
         </div>
       </div>

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+
+function formatDate(value) {
+  if (!value) return 'Unknown'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return date.toLocaleString()
+}
+
+function InpFilesModal({ onClose }) {
+  const [files, setFiles] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+    const controller = new AbortController()
+
+    const loadFiles = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const response = await fetch('/api/inp-files', {
+          signal: controller.signal,
+        })
+        if (!response.ok) {
+          throw new Error('Unable to load INP file index.')
+        }
+        const data = await response.json()
+        if (isMounted) {
+          setFiles(Array.isArray(data) ? data : [])
+        }
+      } catch (err) {
+        if (err.name === 'AbortError') return
+        if (isMounted) {
+          setError(err.message)
+          setFiles([])
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadFiles()
+
+    return () => {
+      isMounted = false
+      controller.abort()
+    }
+  }, [])
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="inp-files-title">
+      <div className="modal">
+        <div className="modal-header">
+          <h2 id="inp-files-title">Stored INP Files</h2>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close stored INP files list">
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          {loading && <p>Loading INP files...</p>}
+          {error && <div className="error-banner">{error}</div>}
+          {!loading && !error && files.length === 0 && <p>No INP files have been stored yet.</p>}
+          {!loading && !error && files.length > 0 && (
+            <table className="modal-table">
+              <thead>
+                <tr>
+                  <th scope="col">File Name</th>
+                  <th scope="col">Uploaded</th>
+                </tr>
+              </thead>
+              <tbody>
+                {files.map((file) => (
+                  <tr key={file._id || `${file.filename}-${file.uploadedAt}`}>
+                    <td>{file.filename || 'Unnamed file'}</td>
+                    <td>{formatDate(file.uploadedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default InpFilesModal

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,6 +11,12 @@
   --button-bg: #f9f9f9;
   --output-bg: #f8f8f8;
   --output-border: #ccc;
+  --modal-bg: #ffffff;
+  --backdrop-bg: rgba(0, 0, 0, 0.45);
+  --table-header-bg: #f0f0f0;
+  --error-bg: rgba(211, 47, 47, 0.15);
+  --error-border: rgba(211, 47, 47, 0.4);
+  --error-text: #8b0000;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -26,6 +32,12 @@
   --button-bg: #1a1a1a;
   --output-bg: #1a1a1a;
   --output-border: #555;
+  --modal-bg: #1f1f1f;
+  --backdrop-bg: rgba(0, 0, 0, 0.6);
+  --table-header-bg: #2a2a2a;
+  --error-bg: rgba(244, 67, 54, 0.2);
+  --error-border: rgba(244, 67, 54, 0.4);
+  --error-text: #ffb4b4;
 }
 
 a {

--- a/server.js
+++ b/server.js
@@ -56,6 +56,21 @@ app.post('/api/parse', upload.single('file'), async (req, res) => {
   }
 });
 
+app.get('/api/inp-files', async (req, res) => {
+  try {
+    const db = getDb();
+    const files = await db
+      .collection('parses')
+      .find({}, { projection: { filename: 1, uploadedAt: 1 } })
+      .sort({ uploadedAt: -1 })
+      .toArray();
+    res.json(files);
+  } catch (err) {
+    console.error('Failed to fetch INP files', err);
+    res.status(500).json({ error: 'Failed to fetch INP files' });
+  }
+});
+
 // Fallback to index.html for SPA routing
 app.use((req, res) => {
   res.sendFile(path.join(distPath, 'index.html'));

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -78,6 +78,7 @@ describe('GET /api/inp-files', () => {
         }),
       }),
     });
+    vi.resetModules();
     const { default: app } = await import('../server.js');
     const res = await request(app).get('/api/inp-files');
     expect(res.status).toBe(200);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,10 @@
 import path from 'path';
 import request from 'supertest';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('POST /api/parse', () => {
   it('parses uploaded INP file and saves result', async () => {
@@ -55,5 +59,39 @@ describe('POST /api/parse', () => {
     expect(res.status).toBe(422);
     expect(res.body.error).toBe('Parsing failed: boom');
     spy.mockRestore();
+  });
+});
+
+describe('GET /api/inp-files', () => {
+  it('returns stored INP file metadata', async () => {
+    const records = [
+      { _id: '1', filename: 'first.inp', uploadedAt: '2024-01-01T00:00:00.000Z' },
+      { _id: '2', filename: 'second.inp', uploadedAt: '2024-02-01T00:00:00.000Z' },
+    ];
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({
+        find: () => ({
+          sort: () => ({
+            toArray: () => Promise.resolve(records),
+          }),
+        }),
+      }),
+    });
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(records);
+  });
+
+  it('returns 500 when database access fails', async () => {
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockImplementation(() => {
+      throw new Error('no db');
+    });
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to fetch INP files');
   });
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -89,6 +89,7 @@ describe('GET /api/inp-files', () => {
     vi.spyOn(db, 'getDb').mockImplementation(() => {
       throw new Error('no db');
     });
+    vi.resetModules();
     const { default: app } = await import('../server.js');
     const res = await request(app).get('/api/inp-files');
     expect(res.status).toBe(500);


### PR DESCRIPTION
## Summary
- add a modal in the client to browse stored INP files from MongoDB
- style the modal with theme-aware variables for light and dark modes
- expose an /api/inp-files endpoint and cover it with automated tests

## Testing
- npm run test:server
- npm --prefix client test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68caa3b5ab508332b6cab406f29d15ce