### PR TITLE
docs: align testing guidance with ci

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,58 @@
 # Project Overview
 
-SWMM-GUI is transitioning from a legacy desktop interface to a modern web-based application. The goal is to deliver the same storm water modelling capabilities in a browser while the desktop UI is phased out.
+SWMM-GUI is in the middle of a multi-year migration from a legacy Delphi desktop
+interface to a modern, web-based experience. The goal is to expose the same
+storm-water modeling capabilities that existed on the desktop, but in a
+browser-first UI that is easier to extend, test, and deploy.
 
 ## Directory Layout
 - `server/` – Node.js backend and API layer.
 - `client/` – React front end served by the backend.
-- `Epaswmm5/` – Legacy Delphi code and bindings for SWMM engine.
-- `Components/` - Legacy Delphi code and bindings for SWMM engine.
+- `Epaswmm5/` & `Components/` – Legacy Delphi code and bindings for the SWMM engine.
+- `test/` – Shared utilities and fixtures for integration tests.
 
 ## Tech Stack
-Node.js, React, and MongoDB form the core stack for the web application.
+The current stack is Node.js (v20), React, and MongoDB. TypeScript is gradually
+being introduced in both the server and client folders. Legacy Delphi code is
+retained strictly for reference and should not be modified without prior
+coordination with the maintainers.
+
+## Local Development
+1. Install dependencies with `npm install` at the repo root.
+2. Use `npm run dev` to start the combined development server once the script is
+   introduced. For now, start the pieces manually as noted below.
+3. Frontend-only work can be run with `npm --prefix client start` while
+   backend-only work should use `npm run start` from the repo root.
+4. MongoDB is expected to be available locally on the default port.
+
+## Testing & QA
+- Install dependencies with `npm ci` to mirror the CI workflow.
+- Backend logic is covered by Vitest suites. Run `npm run test:server` before
+  opening a PR.
+- Frontend checks must match the GitHub Action: run `npm --prefix client ci`
+  (installs dependencies), `npm --prefix client run lint`, and
+  `npm --prefix client test`.
+- If you touch Cypress end-to-end specs (future work), run `npm run cypress` and
+  capture failures in the PR description.
 
 ## Contribution Rules
-- **Commit style**: use concise, present-tense messages (e.g., `feat: add map widget`).
-- **Node version**: develop with Node.js v20.
-- **Legacy Delphi code**: files under `Epaswmm5/` and `Components/` are maintained for reference. Avoid modifying them unless coordinated with maintainers and document any required changes.
+- **Commit style** – Use concise, present-tense messages (e.g., `feat: add map widget`).
+- **Formatting** – Prefer Prettier defaults. Do not disable ESLint rules unless
+  essential; instead, update the code to satisfy the linter.
+- **TypeScript** – When adding new files, prefer TypeScript (`.ts`/`.tsx`) over
+  plain JavaScript. Always include explicit types for exported functions.
+- **Testing expectations** – Changes that alter business logic must include unit
+  tests or integration tests demonstrating the new behavior.
+- **Documentation** – Update README or inline comments when behavior changes
+  affect developer workflows.
+
+## Review Checklist
+When opening a PR, confirm the following:
+- [ ] Tests succeed locally (`npm run test:server`).
+- [ ] Frontend checks succeed (`npm --prefix client ci`,
+      `npm --prefix client run lint`, `npm --prefix client test`).
+- [ ] Updated screenshots are attached for UI changes.
+- [ ] Breaking changes are flagged in the PR description.
+- [ ] Any new environment variables are documented with defaults.
+
+Following this guide keeps the migration on track and makes reviews much faster.


### PR DESCRIPTION
## Summary
- document the full set of npm commands executed by GitHub Actions
- add frontend linting and Vitest steps to the contributor checklist

## Testing
- npm run test:server
- npm --prefix client ci
- npm --prefix client run lint
- npm --prefix client test

------
https://chatgpt.com/codex/tasks/task_e_68caa4fb3b108332bacf4cfe2cb092cb