### PR TITLE
feat: allow deleting stored inp files

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -92,6 +92,27 @@ h1 {
   background-color: var(--table-header-bg);
 }
 
+.modal-table .actions-header,
+.modal-table .actions-cell {
+  text-align: right;
+  white-space: nowrap;
+  width: 1%;
+}
+
+.modal-action {
+  background: none;
+  border: 1px solid var(--output-border);
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.modal-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .error-banner {
   margin: 1rem 0;
   padding: 0.75rem 1rem;

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -11,6 +11,7 @@ function InpFilesModal({ onClose }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [deletingId, setDeletingId] = useState(null)
 
   useEffect(() => {
     let isMounted = true
@@ -51,6 +52,27 @@ function InpFilesModal({ onClose }) {
     }
   }, [])
 
+  const handleDelete = async (id) => {
+    setError(null)
+    setDeletingId(id)
+    try {
+      const response = await fetch(`/api/inp-files/${id}`, {
+        method: 'DELETE',
+      })
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error('The selected INP file was not found.')
+        }
+        throw new Error('Failed to delete the selected INP file.')
+      }
+      setFiles((prev) => prev.filter((file) => file._id !== id))
+    } catch (err) {
+      setError(err.message || 'Failed to delete the selected INP file.')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="inp-files-title">
       <div className="modal">
@@ -71,6 +93,9 @@ function InpFilesModal({ onClose }) {
                 <tr>
                   <th scope="col">File Name</th>
                   <th scope="col">Uploaded</th>
+                  <th scope="col" className="actions-header">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -78,6 +103,17 @@ function InpFilesModal({ onClose }) {
                   <tr key={file._id}>
                     <td>{file.filename || 'Unnamed file'}</td>
                     <td>{formatDate(file.uploadedAt)}</td>
+                    <td className="actions-cell">
+                      <button
+                        type="button"
+                        className="modal-action"
+                        onClick={() => handleDelete(file._id)}
+                        disabled={deletingId === file._id}
+                        aria-label={`Delete ${file.filename || 'stored INP file'}`}
+                      >
+                        {deletingId === file._id ? 'Deleting…' : 'Delete'}
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -60,10 +60,16 @@ function InpFilesModal({ onClose }) {
         method: 'DELETE',
       })
       if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error('The selected INP file was not found.')
+        let errorMessage = 'Failed to delete the selected INP file.';
+        try {
+          const errorBody = await response.json();
+          if (errorBody.error) {
+            errorMessage = errorBody.error;
+          }
+        } catch (e) {
+          console.debug('Error parsing error response:', e); // Optional logging
         }
-        throw new Error('Failed to delete the selected INP file.')
+        throw new Error(errorMessage);
       }
       setFiles((prev) => prev.filter((file) => file._id !== id))
     } catch (err) {

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -12,21 +12,21 @@ function createDeferred() {
 
 describe('InpFilesModal', () => {
   const onClose = vi.fn()
-  const originalFetch = global.fetch
+  const originalFetch = globalThis.fetch
 
   beforeEach(() => {
-    global.fetch = vi.fn()
+    globalThis.fetch = vi.fn()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    global.fetch = originalFetch
+    globalThis.fetch = originalFetch
   })
 
   it('deletes a file when the delete button is clicked', async () => {
     const deleteDeferred = createDeferred()
 
-    global.fetch
+    globalThis.fetch
       .mockResolvedValueOnce({
         ok: true,
         json: async () => [
@@ -46,7 +46,7 @@ describe('InpFilesModal', () => {
     fireEvent.click(deleteButton)
 
     expect(deleteButton).toBeDisabled()
-    expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/inp-files/abc123', {
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(2, '/api/inp-files/abc123', {
       method: 'DELETE',
     })
 

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import InpFilesModal from './InpFilesModal'
+
+function createDeferred() {
+  let resolve
+  const promise = new Promise((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('InpFilesModal', () => {
+  const onClose = vi.fn()
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    global.fetch = originalFetch
+  })
+
+  it('deletes a file when the delete button is clicked', async () => {
+    const deleteDeferred = createDeferred()
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            _id: 'abc123',
+            filename: 'Example.inp',
+            uploadedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      })
+      .mockReturnValueOnce(deleteDeferred.promise)
+
+    render(<InpFilesModal onClose={onClose} />)
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete Example.inp' })
+
+    fireEvent.click(deleteButton)
+
+    expect(deleteButton).toBeDisabled()
+    expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/inp-files/abc123', {
+      method: 'DELETE',
+    })
+
+    deleteDeferred.resolve({
+      ok: true,
+      status: 204,
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Example.inp')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
+const { ObjectId } = require('mongodb');
 const { parseInp } = require('./server/inpParser');
 const { connectToDatabase, getDb } = require('./server/db');
 
@@ -68,6 +69,25 @@ app.get('/api/inp-files', async (req, res) => {
   } catch (err) {
     console.error('Failed to fetch INP files', err);
     res.status(500).json({ error: 'Failed to fetch INP files' });
+  }
+});
+
+app.delete('/api/inp-files/:id', async (req, res) => {
+  const { id } = req.params;
+  if (!ObjectId.isValid(id)) {
+    return res.status(400).json({ error: 'Invalid INP file id' });
+  }
+
+  try {
+    const db = getDb();
+    const result = await db.collection('parses').deleteOne({ _id: new ObjectId(id) });
+    if (result.deletedCount === 0) {
+      return res.status(404).json({ error: 'INP file not found' });
+    }
+    return res.status(204).send();
+  } catch (err) {
+    console.error('Failed to delete INP file', err);
+    return res.status(500).json({ error: 'Failed to delete INP file' });
   }
 });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -97,3 +97,57 @@ describe('GET /api/inp-files', () => {
     expect(res.body.error).toBe('Failed to fetch INP files');
   });
 });
+
+describe('DELETE /api/inp-files/:id', () => {
+  it('returns 400 for an invalid id', async () => {
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).delete('/api/inp-files/not-an-id');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid INP file id');
+  });
+
+  it('returns 404 when no document is removed', async () => {
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({
+        deleteOne: () => Promise.resolve({ deletedCount: 0 }),
+      }),
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).delete('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('INP file not found');
+  });
+
+  it('returns 204 when deletion succeeds', async () => {
+    const deleteOne = vi.fn().mockResolvedValue({ deletedCount: 1 });
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({ deleteOne }),
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).delete('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(204);
+    expect(deleteOne).toHaveBeenCalledTimes(1);
+    expect(deleteOne).toHaveBeenCalledWith({ _id: expect.any(Object) });
+  });
+
+  it('returns 500 when deletion throws', async () => {
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({
+        deleteOne: () => {
+          throw new Error('boom');
+        },
+      }),
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).delete('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to delete INP file');
+  });
+});


### PR DESCRIPTION
## Summary
- add a DELETE API for stored INP files with ObjectId validation
- surface delete controls in the stored files modal and align the table layout
- cover the delete interaction with a UI-level test

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68caaff8ebfc8332948877b3a218d76d