### PR TITLE
I have modified client/src/ParseForm.jsx to add a title input field a…

### DIFF
--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -97,6 +97,7 @@ function InpFilesModal({ onClose }) {
             <table className="modal-table">
               <thead>
                 <tr>
+                  <th scope="col">Title</th>
                   <th scope="col">File Name</th>
                   <th scope="col">Uploaded</th>
                   <th scope="col" className="actions-header">
@@ -107,6 +108,7 @@ function InpFilesModal({ onClose }) {
               <tbody>
                 {files.map((file) => (
                   <tr key={file._id}>
+                    <td>{file.title || 'Untitled'}</td>
                     <td>{file.filename || 'Unnamed file'}</td>
                     <td>{formatDate(file.uploadedAt)}</td>
                     <td className="actions-cell">

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -27,6 +27,7 @@ function ParseForm({ setCoordinates }) {
   const handleSubmit = async (e) => {
     e.preventDefault()
     const file = e.target.elements.file.files[0]
+    const title = e.target.elements.title.value
     if (!file) return
 
     if (!file.name.toLowerCase().endsWith('.inp')) {
@@ -37,6 +38,7 @@ function ParseForm({ setCoordinates }) {
 
     const formData = new FormData()
     formData.append('file', file)
+    formData.append('title', title)
     setLoading(true)
     setError(null)
     try {
@@ -70,6 +72,7 @@ function ParseForm({ setCoordinates }) {
       <h2>Parse INP File</h2>
       <form onSubmit={handleSubmit}>
         <input type="file" name="file" accept=".inp" />
+        <input type="text" name="title" placeholder="Title" />
         <button type="submit">Upload</button>
       </form>
       {loading && <p>Parsing...</p>}

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ app.post('/api/parse', upload.single('file'), async (req, res) => {
     try {
       const db = getDb();
       await db.collection('parses').insertOne({
+        title: req.body.title || 'Untitled',
         filename: req.file.originalname,
         uploadedAt: new Date(),
         data: result,
@@ -62,7 +63,7 @@ app.get('/api/inp-files', async (req, res) => {
     const db = getDb();
     const files = await db
       .collection('parses')
-      .find({}, { projection: { filename: 1, uploadedAt: 1 } })
+      .find({}, { projection: { title: 1, filename: 1, uploadedAt: 1 } })
       .sort({ uploadedAt: -1 })
       .toArray();
     res.json(files);


### PR DESCRIPTION
…nd updated the handleSubmit function to send the title in the form data.

The /api/parse endpoint now extracts the title from the form data and saves it to the parses collection in MongoDB.

The /api/inp-files endpoint now includes the title field in the data it returns.

I added a new "Title" column to the table and am rendering the title for each file.