### PR TITLE
Add title metadata to INP uploads

### DIFF
--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -97,6 +97,7 @@ function InpFilesModal({ onClose }) {
             <table className="modal-table">
               <thead>
                 <tr>
+                  <th scope="col">Title</th>
                   <th scope="col">File Name</th>
                   <th scope="col">Uploaded</th>
                   <th scope="col" className="actions-header">
@@ -107,6 +108,7 @@ function InpFilesModal({ onClose }) {
               <tbody>
                 {files.map((file) => (
                   <tr key={file._id}>
+                    <td>{file.title || 'Untitled'}</td>
                     <td>{file.filename || 'Unnamed file'}</td>
                     <td>{formatDate(file.uploadedAt)}</td>
                     <td className="actions-cell">

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -33,6 +33,7 @@ describe('InpFilesModal', () => {
           {
             _id: 'abc123',
             filename: 'Example.inp',
+            title: 'Example model',
             uploadedAt: '2024-01-01T00:00:00.000Z',
           },
         ],
@@ -41,6 +42,7 @@ describe('InpFilesModal', () => {
 
     render(<InpFilesModal onClose={onClose} />)
 
+    expect(await screen.findByText('Example model')).toBeInTheDocument()
     const deleteButton = await screen.findByRole('button', { name: 'Delete Example.inp' })
 
     fireEvent.click(deleteButton)

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -20,6 +20,7 @@ const normalizeCoordinates = (coordinates) => {
 }
 
 function ParseForm({ setCoordinates }) {
+  const [title, setTitle] = useState('')
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -29,6 +30,13 @@ function ParseForm({ setCoordinates }) {
     const file = e.target.elements.file.files[0]
     if (!file) return
 
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      setError('Title is required.')
+      setData(null)
+      return
+    }
+
     if (!file.name.toLowerCase().endsWith('.inp')) {
       setError('Invalid file type. Please upload a .inp file.')
       setData(null)
@@ -37,6 +45,7 @@ function ParseForm({ setCoordinates }) {
 
     const formData = new FormData()
     formData.append('file', file)
+    formData.append('title', trimmedTitle)
     setLoading(true)
     setError(null)
     try {
@@ -47,6 +56,8 @@ function ParseForm({ setCoordinates }) {
       if (!res.ok) throw new Error('Upload failed')
       const result = await res.json()
       setData(result)
+
+      setTitle('')
 
       const normalized = normalizeCoordinates(result.COORDINATES)
       if (!normalized) {
@@ -69,6 +80,15 @@ function ParseForm({ setCoordinates }) {
     <div>
       <h2>Parse INP File</h2>
       <form onSubmit={handleSubmit}>
+        <label htmlFor="title">Title</label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          required
+        />
         <input type="file" name="file" accept=".inp" />
         <button type="submit">Upload</button>
       </form>

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -86,7 +86,12 @@ function ParseForm({ setCoordinates }) {
           name="title"
           type="text"
           value={title}
-          onChange={(event) => setTitle(event.target.value)}
+          onChange={(event) => {
+            setTitle(event.target.value)
+            if (error === 'Title is required.') {
+              setError(null)
+            }
+          }}
           required
         />
         <input type="file" name="file" accept=".inp" />

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -11,12 +11,16 @@ describe('ParseForm', () => {
     })
     const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const titleInput = container.querySelector('input[name="title"]')
+    fireEvent.change(titleInput, { target: { value: 'Test upload' } })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
     fireEvent.submit(container.querySelector('form'))
     await waitFor(() =>
       expect(setCoordinates).toHaveBeenCalledWith([{ id: 'n1', x: 1, y: 2 }])
     )
+    const formData = globalThis.fetch.mock.calls[0][1].body
+    expect(formData.get('title')).toBe('Test upload')
   })
 
   it('shows an error when coordinates are missing or invalid', async () => {
@@ -27,6 +31,8 @@ describe('ParseForm', () => {
     })
     const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const titleInput = container.querySelector('input[name="title"]')
+    fireEvent.change(titleInput, { target: { value: 'Another upload' } })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
     fireEvent.submit(container.querySelector('form'))
@@ -35,6 +41,20 @@ describe('ParseForm', () => {
       expect(
         container.querySelector('.error-banner')?.textContent
       ).toContain('Invalid coordinates data received from server.')
+    )
+  })
+
+  it('prevents submission without a title', async () => {
+    const setCoordinates = vi.fn()
+    globalThis.fetch = vi.fn()
+    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
+    const input = container.querySelector('input[type="file"]')
+    fireEvent.change(input, { target: { files: [file] } })
+    fireEvent.submit(container.querySelector('form'))
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(container.querySelector('.error-banner')?.textContent).toContain(
+      'Title is required.'
     )
   })
 })

--- a/server.js
+++ b/server.js
@@ -35,6 +35,11 @@ app.post('/api/parse', upload.single('file'), async (req, res) => {
     fs.unlink(req.file.path, () => {});
     return res.status(400).json({ error: 'Unsupported file type' });
   }
+  const title = typeof req.body?.title === 'string' ? req.body.title.trim() : '';
+  if (!title) {
+    fs.unlink(req.file.path, () => {});
+    return res.status(400).json({ error: 'Title is required' });
+  }
   try {
     const result = parseInp(req.file.path);
     fs.unlink(req.file.path, () => {});
@@ -45,6 +50,7 @@ app.post('/api/parse', upload.single('file'), async (req, res) => {
       const db = getDb();
       await db.collection('parses').insertOne({
         filename: req.file.originalname,
+        title,
         uploadedAt: new Date(),
         data: result,
       });
@@ -62,7 +68,7 @@ app.get('/api/inp-files', async (req, res) => {
     const db = getDb();
     const files = await db
       .collection('parses')
-      .find({}, { projection: { filename: 1, uploadedAt: 1 } })
+      .find({}, { projection: { filename: 1, title: 1, uploadedAt: 1 } })
       .sort({ uploadedAt: -1 })
       .toArray();
     res.json(files);

--- a/server.js
+++ b/server.js
@@ -68,7 +68,7 @@ app.get('/api/inp-files', async (req, res) => {
     const db = getDb();
     const files = await db
       .collection('parses')
-      .find({}, { projection: { filename: 1, title: 1, uploadedAt: 1 } })
+      .find({}, { projection: {  title: 1, filename: 1,uploadedAt: 1 } })
       .sort({ uploadedAt: -1 })
       .toArray();
     res.json(files);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -15,11 +15,19 @@ describe('POST /api/parse', () => {
     });
     const { default: app } = await import('../server.js');
     const file = path.join(__dirname, 'data', 'sample.inp');
-    const res = await request(app).post('/api/parse').attach('file', file);
+    const res = await request(app)
+      .post('/api/parse')
+      .field('title', 'Sample Model')
+      .attach('file', file);
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('JUNCTIONS');
     expect(res.body.JUNCTIONS[0]).toMatchObject({ id: 'J1', elevation: 0 });
-    expect(insertOne).toHaveBeenCalled();
+    expect(insertOne).toHaveBeenCalledWith({
+      filename: 'sample.inp',
+      title: 'Sample Model',
+      uploadedAt: expect.any(Date),
+      data: expect.any(Object),
+    });
   });
 
   it('returns 400 when no file uploaded', async () => {
@@ -32,7 +40,10 @@ describe('POST /api/parse', () => {
   it('returns 422 for invalid INP file', async () => {
     const { default: app } = await import('../server.js');
     const file = path.join(__dirname, 'data', 'invalid.inp');
-    const res = await request(app).post('/api/parse').attach('file', file);
+    const res = await request(app)
+      .post('/api/parse')
+      .field('title', 'Invalid Model')
+      .attach('file', file);
     expect(res.status).toBe(422);
     expect(res.body.error).toMatch(/invalid or empty/i);
   });
@@ -40,7 +51,10 @@ describe('POST /api/parse', () => {
   it('returns 400 for unsupported file type', async () => {
     const { default: app } = await import('../server.js');
     const file = path.join(__dirname, 'data', 'sample.txt');
-    const res = await request(app).post('/api/parse').attach('file', file);
+    const res = await request(app)
+      .post('/api/parse')
+      .field('title', 'Text upload')
+      .attach('file', file);
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Unsupported file type');
   });
@@ -55,18 +69,39 @@ describe('POST /api/parse', () => {
       });
     const app = require('../server.js');
     const file = path.join(__dirname, 'data', 'sample.inp');
-    const res = await request(app).post('/api/parse').attach('file', file);
+    const res = await request(app)
+      .post('/api/parse')
+      .field('title', 'Explosive upload')
+      .attach('file', file);
     expect(res.status).toBe(422);
     expect(res.body.error).toBe('Parsing failed: boom');
     spy.mockRestore();
+  });
+
+  it('returns 400 when title is missing', async () => {
+    const { default: app } = await import('../server.js');
+    const file = path.join(__dirname, 'data', 'sample.inp');
+    const res = await request(app).post('/api/parse').attach('file', file);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Title is required');
   });
 });
 
 describe('GET /api/inp-files', () => {
   it('returns stored INP file metadata', async () => {
     const records = [
-      { _id: '1', filename: 'first.inp', uploadedAt: '2024-01-01T00:00:00.000Z' },
-      { _id: '2', filename: 'second.inp', uploadedAt: '2024-02-01T00:00:00.000Z' },
+      {
+        _id: '1',
+        filename: 'first.inp',
+        title: 'First model',
+        uploadedAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        _id: '2',
+        filename: 'second.inp',
+        title: 'Second model',
+        uploadedAt: '2024-02-01T00:00:00.000Z',
+      },
     ];
     const db = require('../server/db');
     vi.spyOn(db, 'getDb').mockReturnValue({


### PR DESCRIPTION
## Summary
- add a required title field to the INP upload form and validate it on the client
- persist upload titles in MongoDB and expose them through the stored files API
- display stored titles in the modal table and extend server/client test coverage

## Testing
- npm run test:server
- npm --prefix client test -- --run
- npm --prefix client run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd5e706d20833287063a465a60650d