### PR TITLE
feat: move inp upload into modal

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import MapView from './MapView'
 import ResultsView from './ResultsView'
-import ParseForm from './ParseForm'
 import InpFilesModal from './InpFilesModal'
 
 function App() {
@@ -46,11 +45,13 @@ function App() {
       </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
-      <ParseForm setCoordinates={setCoordinates} />
       <MapView coordinates={coordinates} />
       <ResultsView />
       {showInpFilesModal && (
-        <InpFilesModal onClose={() => setShowInpFilesModal(false)} />
+        <InpFilesModal
+          onClose={() => setShowInpFilesModal(false)}
+          setCoordinates={setCoordinates}
+        />
       )}
     </div>
   )

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import ParseForm from './ParseForm'
 
 function formatDate(value) {
   if (!value) return 'Unknown'
@@ -7,50 +8,40 @@ function formatDate(value) {
   return date.toLocaleString()
 }
 
-function InpFilesModal({ onClose }) {
+function InpFilesModal({ onClose, setCoordinates = () => {} }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [deletingId, setDeletingId] = useState(null)
 
-  useEffect(() => {
-    let isMounted = true
-    const controller = new AbortController()
-
-    const loadFiles = async () => {
-      try {
-        setLoading(true)
-        setError(null)
-        const response = await fetch('/api/inp-files', {
-          signal: controller.signal,
-        })
-        if (!response.ok) {
-          throw new Error('Unable to load INP file index.')
-        }
-        const data = await response.json()
-        if (isMounted) {
-          setFiles(Array.isArray(data) ? data : [])
-        }
-      } catch (err) {
-        if (err.name === 'AbortError') return
-        if (isMounted) {
-          setError(err.message)
-          setFiles([])
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false)
-        }
+  const loadFiles = useCallback(async (signal) => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await fetch('/api/inp-files', {
+        signal,
+      })
+      if (!response.ok) {
+        throw new Error('Unable to load INP file index.')
       }
-    }
-
-    loadFiles()
-
-    return () => {
-      isMounted = false
-      controller.abort()
+      const data = await response.json()
+      setFiles(Array.isArray(data) ? data : [])
+    } catch (err) {
+      if (err.name === 'AbortError') return
+      setError(err.message)
+      setFiles([])
+    } finally {
+      setLoading(false)
     }
   }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    loadFiles(controller.signal)
+    return () => {
+      controller.abort()
+    }
+  }, [loadFiles])
 
   const handleDelete = async (id) => {
     setError(null)
@@ -89,6 +80,7 @@ function InpFilesModal({ onClose }) {
           </button>
         </div>
         <div className="modal-body">
+          <ParseForm setCoordinates={setCoordinates} onSuccess={() => loadFiles()} />
           {loading ? (
             <p>Loading INP files...</p>
           ) : error ? (

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -61,4 +61,55 @@ describe('InpFilesModal', () => {
       expect(screen.queryByText('Example.inp')).not.toBeInTheDocument()
     })
   })
+
+  it('reloads the index after a successful upload', async () => {
+    const setCoordinates = vi.fn()
+    const file = new File(['dummy'], 'upload.inp', { type: 'text/plain' })
+
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          COORDINATES: [
+            { id: 'n1', x: 1, y: 2 },
+            { id: 'n2', x: 3, y: 4 },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            _id: 'new123',
+            filename: 'upload.inp',
+            title: 'Uploaded Model',
+            uploadedAt: '2024-05-01T12:00:00.000Z',
+          },
+        ],
+      })
+
+    render(<InpFilesModal onClose={onClose} setCoordinates={setCoordinates} />)
+
+    const titleInput = await screen.findByLabelText('Title')
+    fireEvent.change(titleInput, { target: { value: 'Uploaded Model' } })
+
+    const fileInput = titleInput.form.querySelector('input[type="file"]')
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    fireEvent.submit(titleInput.form)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(3, '/api/inp-files', {
+        signal: undefined,
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Uploaded Model')).toBeInTheDocument()
+    })
+  })
 })

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const normalizeCoordinates = (coordinates) => {
   if (!Array.isArray(coordinates)) return null
@@ -24,8 +24,9 @@ function ParseForm({ setCoordinates = () => {}, onSuccess }) {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [pendingSubmission, setPendingSubmission] = useState(null)
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = (e) => {
     e.preventDefault()
     const file = e.target.elements.file.files[0]
     if (!file) return
@@ -48,36 +49,60 @@ function ParseForm({ setCoordinates = () => {}, onSuccess }) {
     formData.append('title', trimmedTitle)
     setLoading(true)
     setError(null)
-    try {
-      const res = await fetch('/api/parse', {
-        method: 'POST',
-        body: formData,
-      })
-      if (!res.ok) throw new Error('Upload failed')
-      const result = await res.json()
-      setData(result)
-
-      setTitle('')
-
-      const normalized = normalizeCoordinates(result.COORDINATES)
-      if (!normalized) {
-        setCoordinates([])
-        setData(null)
-        setError('Invalid coordinates data received from server.')
-        return
-      }
-
-      setCoordinates(normalized)
-      if (onSuccess) {
-        onSuccess(result)
-      }
-    } catch (err) {
-      setError(err.message)
-      setData(null)
-    } finally {
-      setLoading(false)
-    }
+    setPendingSubmission({ formData })
   }
+
+  useEffect(() => {
+    if (!pendingSubmission) return undefined
+
+    const controller = new AbortController()
+    let isActive = true
+
+    const submit = async () => {
+      try {
+        const res = await fetch('/api/parse', {
+          method: 'POST',
+          body: pendingSubmission.formData,
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error('Upload failed')
+        const result = await res.json()
+        if (!isActive) return
+
+        setData(result)
+        setTitle('')
+
+        const normalized = normalizeCoordinates(result.COORDINATES)
+        if (!normalized) {
+          setCoordinates([])
+          setData(null)
+          setError('Invalid coordinates data received from server.')
+          return
+        }
+
+        setCoordinates(normalized)
+        if (onSuccess) {
+          onSuccess(result)
+        }
+      } catch (err) {
+        if (!isActive || err.name === 'AbortError') return
+        setError(err.message)
+        setData(null)
+      } finally {
+        if (isActive) {
+          setLoading(false)
+          setPendingSubmission(null)
+        }
+      }
+    }
+
+    submit()
+
+    return () => {
+      isActive = false
+      controller.abort()
+    }
+  }, [pendingSubmission, onSuccess, setCoordinates])
 
   return (
     <div>

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -19,7 +19,7 @@ const normalizeCoordinates = (coordinates) => {
   return normalized
 }
 
-function ParseForm({ setCoordinates }) {
+function ParseForm({ setCoordinates = () => {}, onSuccess }) {
   const [title, setTitle] = useState('')
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
@@ -68,6 +68,9 @@ function ParseForm({ setCoordinates }) {
       }
 
       setCoordinates(normalized)
+      if (onSuccess) {
+        onSuccess(result)
+      }
     } catch (err) {
       setError(err.message)
       setData(null)


### PR DESCRIPTION
## Summary
- move the INP upload form into the stored INP files modal so the button lives in the popup
- reuse the modal to refresh the index after uploads and handle optional coordinate callbacks
- add a regression test covering an upload from the modal

## Testing
- npm --prefix client test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce19a627308332b65d6a8d5e0f51c4