### PR TITLE
feat: embed upload form in inp modal

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import MapView from './MapView'
 import ResultsView from './ResultsView'
-import ParseForm from './ParseForm'
 import InpFilesModal from './InpFilesModal'
 
 function App() {
@@ -46,11 +45,22 @@ function App() {
       </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
-      <ParseForm setCoordinates={setCoordinates} />
       <MapView coordinates={coordinates} />
       <ResultsView />
       {showInpFilesModal && (
-        <InpFilesModal onClose={() => setShowInpFilesModal(false)} />
+        <InpFilesModal
+          onClose={() => setShowInpFilesModal(false)}
+          onUploadSuccess={(_, normalized) => {
+            if (Array.isArray(normalized)) {
+              setCoordinates(normalized)
+            }
+          }}
+          onUploadError={(message) => {
+            if (message === 'Invalid coordinates data received from server.') {
+              setCoordinates([])
+            }
+          }}
+        />
       )}
     </div>
   )

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import ParseForm from './ParseForm'
 
 function formatDate(value) {
   if (!value) return 'Unknown'
@@ -7,49 +8,61 @@ function formatDate(value) {
   return date.toLocaleString()
 }
 
-function InpFilesModal({ onClose }) {
+function InpFilesModal({ onClose, onUploadSuccess, onUploadError }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [showUploader, setShowUploader] = useState(false)
+  const isMountedRef = useRef(true)
 
-  useEffect(() => {
-    let isMounted = true
-    const controller = new AbortController()
-
-    const loadFiles = async () => {
+  const loadFiles = useCallback(
+    async (signal) => {
       try {
-        setLoading(true)
-        setError(null)
-        const response = await fetch('/api/inp-files', {
-          signal: controller.signal,
-        })
+        if (isMountedRef.current) {
+          setLoading(true)
+          setError(null)
+        }
+        const response = await fetch(
+          '/api/inp-files',
+          signal ? { signal } : undefined
+        )
         if (!response.ok) {
           throw new Error('Unable to load INP file index.')
         }
         const data = await response.json()
-        if (isMounted) {
+        if (isMountedRef.current) {
           setFiles(Array.isArray(data) ? data : [])
         }
       } catch (err) {
         if (err.name === 'AbortError') return
-        if (isMounted) {
+        if (isMountedRef.current) {
           setError(err.message)
           setFiles([])
         }
       } finally {
-        if (isMounted) {
+        if (isMountedRef.current) {
           setLoading(false)
         }
       }
-    }
+    },
+    []
+  )
 
-    loadFiles()
-
+  useEffect(() => {
+    isMountedRef.current = true
+    const controller = new AbortController()
+    loadFiles(controller.signal)
     return () => {
-      isMounted = false
+      isMountedRef.current = false
       controller.abort()
     }
-  }, [])
+  }, [loadFiles])
+
+  const handleUploadSuccess = (result, coordinates) => {
+    setShowUploader(false)
+    loadFiles()
+    onUploadSuccess?.(result, coordinates)
+  }
 
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="inp-files-title">
@@ -61,6 +74,20 @@ function InpFilesModal({ onClose }) {
           </button>
         </div>
         <div className="modal-body">
+          <button
+            type="button"
+            className="modal-toggle"
+            onClick={() => setShowUploader((prev) => !prev)}
+            aria-expanded={showUploader}
+          >
+            {showUploader ? 'Hide upload form' : 'Upload new INP file'}
+          </button>
+          {showUploader && (
+            <ParseForm
+              onUploadSuccess={handleUploadSuccess}
+              onUploadError={onUploadError}
+            />
+          )}
           {loading ? (
             <p>Loading INP files...</p>
           ) : error ? (

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -1,0 +1,33 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import InpFilesModal from './InpFilesModal'
+
+describe('InpFilesModal', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('shows the upload form when toggled', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+    globalThis.fetch = fetchMock
+    const { container, getByRole } = render(
+      <InpFilesModal onClose={() => {}} />
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    expect(container.querySelector('input[type="file"]')).toBeNull()
+
+    const toggleButton = getByRole('button', { name: /upload new inp file/i })
+    fireEvent.click(toggleButton)
+
+    expect(container.querySelector('input[type="file"]')).not.toBeNull()
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+  })
+})

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 const normalizeCoordinates = (coordinates) => {
   if (!Array.isArray(coordinates)) return null
@@ -19,19 +19,22 @@ const normalizeCoordinates = (coordinates) => {
   return normalized
 }
 
-function ParseForm({ setCoordinates }) {
+function ParseForm({ onUploadSuccess, onUploadError, onUploadStart }) {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+  const formRef = useRef(null)
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const file = e.target.elements.file.files[0]
+    const form = e.target
+    const file = form.elements.file.files[0]
     if (!file) return
 
     if (!file.name.toLowerCase().endsWith('.inp')) {
       setError('Invalid file type. Please upload a .inp file.')
       setData(null)
+      onUploadError?.('Invalid file type. Please upload a .inp file.')
       return
     }
 
@@ -39,6 +42,8 @@ function ParseForm({ setCoordinates }) {
     formData.append('file', file)
     setLoading(true)
     setError(null)
+    setData(null)
+    onUploadStart?.()
     try {
       const res = await fetch('/api/parse', {
         method: 'POST',
@@ -46,20 +51,23 @@ function ParseForm({ setCoordinates }) {
       })
       if (!res.ok) throw new Error('Upload failed')
       const result = await res.json()
-      setData(result)
 
       const normalized = normalizeCoordinates(result.COORDINATES)
       if (!normalized) {
-        setCoordinates([])
+        const message = 'Invalid coordinates data received from server.'
+        setError(message)
         setData(null)
-        setError('Invalid coordinates data received from server.')
+        onUploadError?.(message)
         return
       }
 
-      setCoordinates(normalized)
+      setData(result)
+      formRef.current?.reset()
+      onUploadSuccess?.(result, normalized)
     } catch (err) {
       setError(err.message)
       setData(null)
+      onUploadError?.(err.message)
     } finally {
       setLoading(false)
     }
@@ -68,7 +76,7 @@ function ParseForm({ setCoordinates }) {
   return (
     <div>
       <h2>Parse INP File</h2>
-      <form onSubmit={handleSubmit}>
+      <form ref={formRef} onSubmit={handleSubmit}>
         <input type="file" name="file" accept=".inp" />
         <button type="submit">Upload</button>
       </form>

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -1,40 +1,65 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import ParseForm from './ParseForm'
 
 describe('ParseForm', () => {
-  it('passes coordinates from parser to setCoordinates', async () => {
-    const setCoordinates = vi.fn()
-    globalThis.fetch = vi.fn().mockResolvedValue({
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('invokes onUploadSuccess with normalized coordinates', async () => {
+    const onUploadSuccess = vi.fn()
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ COORDINATES: [{ id: 'n1', x: 1, y: 2 }] })
+      json: async () => ({
+        COORDINATES: [
+          { id: 'n1', x: '1', y: 2 },
+          { id: 'n2', x: 3, y: '4' }
+        ],
+        meta: 'info',
+      }),
     })
-    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    globalThis.fetch = fetchMock
+    const { container } = render(<ParseForm onUploadSuccess={onUploadSuccess} />)
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
     fireEvent.submit(container.querySelector('form'))
-    await waitFor(() =>
-      expect(setCoordinates).toHaveBeenCalledWith([{ id: 'n1', x: 1, y: 2 }])
-    )
+    await waitFor(() => expect(onUploadSuccess).toHaveBeenCalledTimes(1))
+    const [result, normalized] = onUploadSuccess.mock.calls[0]
+    expect(result).toEqual({
+      COORDINATES: [
+        { id: 'n1', x: '1', y: 2 },
+        { id: 'n2', x: 3, y: '4' }
+      ],
+      meta: 'info',
+    })
+    expect(normalized).toEqual([
+      { id: 'n1', x: 1, y: 2 },
+      { id: 'n2', x: 3, y: 4 }
+    ])
+    expect(input.value).toBe('')
   })
 
   it('shows an error when coordinates are missing or invalid', async () => {
-    const setCoordinates = vi.fn()
+    const onUploadError = vi.fn()
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({})
     })
-    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const { container } = render(<ParseForm onUploadError={onUploadError} />)
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
     fireEvent.submit(container.querySelector('form'))
-    await waitFor(() => expect(setCoordinates).toHaveBeenCalledWith([]))
     await waitFor(() =>
       expect(
         container.querySelector('.error-banner')?.textContent
       ).toContain('Invalid coordinates data received from server.')
     )
+    expect(onUploadError).toHaveBeenCalledWith('Invalid coordinates data received from server.')
   })
 })


### PR DESCRIPTION
## Summary
- refactor the parse form to use callbacks, validate coordinate payloads, and reset itself after successful uploads
- move the upload form into the INP files modal with a toggle, refreshing the stored file index and forwarding callbacks to the map view
- update unit tests for the new API and cover the modal uploader toggle

## Testing
- npm --prefix client test

------
https://chatgpt.com/codex/tasks/task_e_68cab0018fb883329cb2caf8395abdd2