### PR TITLE
feat: open upload form in modal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -8,7 +8,7 @@ h1 {
   text-align: center;
 }
 
-.inp-files-button {
+.action-button {
   display: block;
   margin: 1rem auto;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ function App() {
   const [coordinates, setCoordinates] = useState([])
   const [theme, setTheme] = useState('light')
   const [showInpFilesModal, setShowInpFilesModal] = useState(false)
+  const [showUploadModal, setShowUploadModal] = useState(false)
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
@@ -38,7 +39,14 @@ function App() {
         {theme === 'light' ? '🌞' : '🌜'}
       </button>
       <button
-        className="inp-files-button"
+        className="action-button"
+        type="button"
+        onClick={() => setShowUploadModal(true)}
+      >
+        Upload INP File
+      </button>
+      <button
+        className="action-button"
         type="button"
         onClick={() => setShowInpFilesModal(true)}
       >
@@ -46,9 +54,14 @@ function App() {
       </button>
       <h1>SWMM Output</h1>
       <pre className="output">{output}</pre>
-      <ParseForm setCoordinates={setCoordinates} />
       <MapView coordinates={coordinates} />
       <ResultsView />
+      {showUploadModal && (
+        <ParseForm
+          setCoordinates={setCoordinates}
+          onClose={() => setShowUploadModal(false)}
+        />
+      )}
       {showInpFilesModal && (
         <InpFilesModal onClose={() => setShowInpFilesModal(false)} />
       )}

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const normalizeCoordinates = (coordinates) => {
   if (!Array.isArray(coordinates)) return null
@@ -19,15 +19,21 @@ const normalizeCoordinates = (coordinates) => {
   return normalized
 }
 
-function ParseForm({ setCoordinates }) {
+function ParseForm({ setCoordinates, onClose }) {
   const [title, setTitle] = useState('')
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
+  const titleInputRef = useRef(null)
+
+  useEffect(() => {
+    titleInputRef.current?.focus()
+  }, [])
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const file = e.target.elements.file.files[0]
+    const formElement = e.target
+    const file = formElement.elements.file.files[0]
     if (!file) return
 
     const trimmedTitle = title.trim()
@@ -58,6 +64,7 @@ function ParseForm({ setCoordinates }) {
       setData(result)
 
       setTitle('')
+      formElement.reset()
 
       const normalized = normalizeCoordinates(result.COORDINATES)
       if (!normalized) {
@@ -76,32 +83,63 @@ function ParseForm({ setCoordinates }) {
     }
   }
 
+  const handleBackdropMouseDown = (event) => {
+    if (event.target === event.currentTarget && onClose) {
+      onClose()
+    }
+  }
+
   return (
-    <div>
-      <h2>Parse INP File</h2>
-      <form onSubmit={handleSubmit}>
-        <label htmlFor="title">Title</label>
-        <input
-          id="title"
-          name="title"
-          type="text"
-          value={title}
-          onChange={(event) => {
-            setTitle(event.target.value)
-            if (error === 'Title is required.') {
-              setError(null)
-            }
-          }}
-          required
-        />
-        <input type="file" name="file" accept=".inp" />
-        <button type="submit">Upload</button>
-      </form>
-      {loading && <p>Parsing...</p>}
-      {error && <div className="error-banner">{error}</div>}
-      {data && (
-        <pre className="output">{JSON.stringify(data, null, 2)}</pre>
-      )}
+    <div
+      className="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="parse-form-title"
+      onMouseDown={handleBackdropMouseDown}
+    >
+      <div className="modal" role="document">
+        <div className="modal-header">
+          <h2 id="parse-form-title">Parse INP File</h2>
+          {onClose && (
+            <button
+              type="button"
+              className="modal-close"
+              onClick={onClose}
+              aria-label="Close upload form"
+            >
+              ×
+            </button>
+          )}
+        </div>
+        <div className="modal-body">
+          <form onSubmit={handleSubmit}>
+            <label htmlFor="title">Title</label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              value={title}
+              ref={titleInputRef}
+              onChange={(event) => {
+                setTitle(event.target.value)
+                if (error === 'Title is required.') {
+                  setError(null)
+                }
+              }}
+              required
+            />
+            <input type="file" name="file" accept=".inp" />
+            <button type="submit" disabled={loading}>
+              {loading ? 'Uploading…' : 'Upload'}
+            </button>
+          </form>
+          {loading && <p>Parsing...</p>}
+          {error && <div className="error-banner">{error}</div>}
+          {data && (
+            <pre className="output">{JSON.stringify(data, null, 2)}</pre>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -1,15 +1,22 @@
-import { render, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import ParseForm from './ParseForm'
 
 describe('ParseForm', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
   it('passes coordinates from parser to setCoordinates', async () => {
     const setCoordinates = vi.fn()
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ COORDINATES: [{ id: 'n1', x: 1, y: 2 }] })
     })
-    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const { container } = render(
+      <ParseForm setCoordinates={setCoordinates} onClose={() => {}} />
+    )
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const titleInput = container.querySelector('input[name="title"]')
     fireEvent.change(titleInput, { target: { value: 'Test upload' } })
@@ -29,7 +36,9 @@ describe('ParseForm', () => {
       ok: true,
       json: async () => ({})
     })
-    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const { container } = render(
+      <ParseForm setCoordinates={setCoordinates} onClose={() => {}} />
+    )
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const titleInput = container.querySelector('input[name="title"]')
     fireEvent.change(titleInput, { target: { value: 'Another upload' } })
@@ -47,7 +56,9 @@ describe('ParseForm', () => {
   it('prevents submission without a title', async () => {
     const setCoordinates = vi.fn()
     globalThis.fetch = vi.fn()
-    const { container } = render(<ParseForm setCoordinates={setCoordinates} />)
+    const { container } = render(
+      <ParseForm setCoordinates={setCoordinates} onClose={() => {}} />
+    )
     const file = new File(['dummy'], 'test.inp', { type: 'text/plain' })
     const input = container.querySelector('input[type="file"]')
     fireEvent.change(input, { target: { files: [file] } })
@@ -56,5 +67,34 @@ describe('ParseForm', () => {
     expect(container.querySelector('.error-banner')?.textContent).toContain(
       'Title is required.'
     )
+  })
+
+  it('allows closing the modal via the close button', () => {
+    const onClose = vi.fn()
+    const { getByLabelText } = render(
+      <ParseForm setCoordinates={() => {}} onClose={onClose} />
+    )
+    fireEvent.click(getByLabelText('Close upload form'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the modal when clicking on the backdrop', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <ParseForm setCoordinates={() => {}} onClose={onClose} />
+    )
+    const backdrop = container.querySelector('.modal-backdrop')
+    fireEvent.mouseDown(backdrop)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close the modal when interacting inside it', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <ParseForm setCoordinates={() => {}} onClose={onClose} />
+    )
+    const modal = container.querySelector('.modal')
+    fireEvent.mouseDown(modal)
+    expect(onClose).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- wrap the INP upload form in a modal dialog triggered by a new action button
- enhance the parse form with focus management, loading states, and backdrop closing
- expand tests to cover modal behavior and interactions

## Testing
- npm --prefix client run lint
- npm --prefix client test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd6666b4d08332a9f79490567546f4