### PR TITLE
feat: trap focus within parse modal

### DIFF
--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const normalizeCoordinates = (coordinates) => {
   if (!Array.isArray(coordinates)) return null
@@ -25,10 +25,81 @@ function ParseForm({ setCoordinates, onClose }) {
   const [error, setError] = useState(null)
   const [loading, setLoading] = useState(false)
   const titleInputRef = useRef(null)
+  const modalRef = useRef(null)
+  const focusableElementsRef = useRef([])
+
+  const collectFocusableElements = useCallback(() => {
+    const modal = modalRef.current
+    if (!modal) return
+
+    const focusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([type="hidden"]):not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(', ')
+
+    focusableElementsRef.current = Array.from(
+      modal.querySelectorAll(focusableSelector)
+    ).filter((element) => !element.hasAttribute('aria-hidden'))
+
+    if (focusableElementsRef.current.length === 0) {
+      modal.focus()
+    }
+  }, [])
 
   useEffect(() => {
     titleInputRef.current?.focus()
   }, [])
+
+  useEffect(() => {
+    collectFocusableElements()
+  }, [collectFocusableElements, loading, data, error])
+
+  useEffect(() => {
+    const modal = modalRef.current
+    if (!modal) return
+
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Tab') return
+
+      collectFocusableElements()
+
+      const focusableElements = focusableElementsRef.current
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const [firstElement] = focusableElements
+      const lastElement = focusableElements[focusableElements.length - 1]
+      const activeElement = document.activeElement
+
+      if (event.shiftKey) {
+        if (
+          activeElement === firstElement ||
+          !modal.contains(activeElement)
+        ) {
+          lastElement.focus()
+          event.preventDefault()
+        }
+        return
+      }
+
+      if (activeElement === lastElement || !modal.contains(activeElement)) {
+        firstElement.focus()
+        event.preventDefault()
+      }
+    }
+
+    modal.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      modal.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [collectFocusableElements])
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -97,7 +168,7 @@ function ParseForm({ setCoordinates, onClose }) {
       aria-labelledby="parse-form-title"
       onMouseDown={handleBackdropMouseDown}
     >
-      <div className="modal" role="document">
+      <div className="modal" role="document" tabIndex={-1} ref={modalRef}>
         <div className="modal-header">
           <h2 id="parse-form-title">Parse INP File</h2>
           {onClose && (

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -65,8 +65,6 @@ function ParseForm({ setCoordinates, onClose }) {
     const handleKeyDown = (event) => {
       if (event.key !== 'Tab') return
 
-      collectFocusableElements()
-
       const focusableElements = focusableElementsRef.current
       if (focusableElements.length === 0) {
         event.preventDefault()

--- a/client/src/ParseForm.test.jsx
+++ b/client/src/ParseForm.test.jsx
@@ -97,4 +97,34 @@ describe('ParseForm', () => {
     fireEvent.mouseDown(modal)
     expect(onClose).not.toHaveBeenCalled()
   })
+
+  it('cycles focus to the first element when tabbing forward from the last', () => {
+    const { getByLabelText, getByText } = render(
+      <ParseForm setCoordinates={() => {}} onClose={() => {}} />
+    )
+
+    const submitButton = getByText('Upload')
+    submitButton.focus()
+    expect(document.activeElement).toBe(submitButton)
+
+    fireEvent.keyDown(submitButton, { key: 'Tab', code: 'Tab' })
+
+    const closeButton = getByLabelText('Close upload form')
+    expect(document.activeElement).toBe(closeButton)
+  })
+
+  it('cycles focus to the last element when shift+tabbing from the first', () => {
+    const { getByLabelText, getByText } = render(
+      <ParseForm setCoordinates={() => {}} onClose={() => {}} />
+    )
+
+    const closeButton = getByLabelText('Close upload form')
+    closeButton.focus()
+    expect(document.activeElement).toBe(closeButton)
+
+    fireEvent.keyDown(closeButton, { key: 'Tab', code: 'Tab', shiftKey: true })
+
+    const submitButton = getByText('Upload')
+    expect(document.activeElement).toBe(submitButton)
+  })
 })


### PR DESCRIPTION
## Summary
- add focus trapping logic and focusable element collection to the ParseForm modal
- ensure the modal container is focusable when no interactive children exist
- cover tabbing and reverse tabbing focus loops with ParseForm unit tests

## Testing
- npm --prefix client run lint
- npm --prefix client test

------
https://chatgpt.com/codex/tasks/task_e_68ce21cfd5448332a94490ead1633122