### PR TITLE
Move INP upload button into stored files modal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -57,6 +57,12 @@ h1 {
   border-bottom: 1px solid var(--output-border);
 }
 
+.modal-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .modal-body {
   padding: 1rem 1.5rem;
   overflow-y: auto;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,13 +41,6 @@ function App() {
       <button
         className="action-button"
         type="button"
-        onClick={() => setShowUploadModal(true)}
-      >
-        Upload INP File
-      </button>
-      <button
-        className="action-button"
-        type="button"
         onClick={() => setShowInpFilesModal(true)}
       >
         View Stored INP Files
@@ -63,7 +56,13 @@ function App() {
         />
       )}
       {showInpFilesModal && (
-        <InpFilesModal onClose={() => setShowInpFilesModal(false)} />
+        <InpFilesModal
+          onClose={() => setShowInpFilesModal(false)}
+          onUploadClick={() => {
+            setShowUploadModal(true)
+            setShowInpFilesModal(false)
+          }}
+        />
       )}
     </div>
   )

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -7,7 +7,7 @@ function formatDate(value) {
   return date.toLocaleString()
 }
 
-function InpFilesModal({ onClose }) {
+function InpFilesModal({ onClose, onUploadClick }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -84,9 +84,16 @@ function InpFilesModal({ onClose }) {
       <div className="modal">
         <div className="modal-header">
           <h2 id="inp-files-title">Stored INP Files</h2>
-          <button type="button" className="modal-close" onClick={onClose} aria-label="Close stored INP files list">
-            ×
-          </button>
+          <div className="modal-header-actions">
+            {onUploadClick && (
+              <button type="button" className="modal-action" onClick={onUploadClick}>
+                Upload INP File
+              </button>
+            )}
+            <button type="button" className="modal-close" onClick={onClose} aria-label="Close stored INP files list">
+              ×
+            </button>
+          </div>
         </div>
         <div className="modal-body">
           {loading ? (

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -11,10 +11,13 @@ function createDeferred() {
 }
 
 describe('InpFilesModal', () => {
-  const onClose = vi.fn()
+  let onClose
+  let onUploadClick
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
+    onClose = vi.fn()
+    onUploadClick = vi.fn()
     globalThis.fetch = vi.fn()
   })
 
@@ -40,7 +43,7 @@ describe('InpFilesModal', () => {
       })
       .mockReturnValueOnce(deleteDeferred.promise)
 
-    render(<InpFilesModal onClose={onClose} />)
+    render(<InpFilesModal onClose={onClose} onUploadClick={onUploadClick} />)
 
     expect(await screen.findByText('Example model')).toBeInTheDocument()
     const deleteButton = await screen.findByRole('button', { name: 'Delete Example.inp' })
@@ -60,5 +63,19 @@ describe('InpFilesModal', () => {
     await waitFor(() => {
       expect(screen.queryByText('Example.inp')).not.toBeInTheDocument()
     })
+  })
+
+  it('renders the upload button and triggers callback when clicked', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+
+    render(<InpFilesModal onClose={onClose} onUploadClick={onUploadClick} />)
+
+    const uploadButtons = await screen.findAllByRole('button', { name: 'Upload INP File' })
+    uploadButtons.forEach((button) => fireEvent.click(button))
+
+    expect(onUploadClick).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- remove the standalone Upload INP File button from the main view
- add an upload action within the Stored INP Files modal and plumb the callback
- update styling and tests to cover the new upload entry point

## Testing
- npm --prefix client run lint
- npm --prefix client test


------
https://chatgpt.com/codex/tasks/task_e_68ce2220dd54833282fdae5922e422e3