### PR TITLE
feat: load stored INP files from index modal

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import './App.css'
 import MapView from './MapView'
 import ResultsView from './ResultsView'
 import ParseForm from './ParseForm'
 import InpFilesModal from './InpFilesModal'
+import normalizeCoordinates from './normalizeCoordinates'
 
 function App() {
   const [output, setOutput] = useState('Loading...')
@@ -11,7 +12,7 @@ function App() {
   const [theme, setTheme] = useState('light')
   const [showInpFilesModal, setShowInpFilesModal] = useState(false)
   const [showUploadModal, setShowUploadModal] = useState(false)
-
+  
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
   }, [theme])
@@ -26,6 +27,35 @@ function App() {
   const toggleTheme = () => {
     setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
   }
+
+  const handleLoadInpFile = useCallback(async (id) => {
+    const response = await fetch(`/api/inp-files/${id}`)
+    if (!response.ok) {
+      let message = 'Failed to load the selected INP file.'
+      try {
+        const errorBody = await response.json()
+        if (errorBody?.error) {
+          message = errorBody.error
+        }
+      } catch (err) {
+        console.debug('Error parsing INP load error response:', err)
+      }
+      throw new Error(message)
+    }
+
+    const payload = await response.json()
+    const normalized = normalizeCoordinates(payload?.data?.COORDINATES)
+
+    if (!normalized) {
+      setCoordinates([])
+      throw new Error('Loaded INP file is missing valid coordinate data.')
+    }
+
+    setCoordinates([])
+    setTimeout(() => {
+      setCoordinates(normalized)
+    }, 0)
+  }, [setCoordinates])
 
   return (
     <div>
@@ -60,6 +90,10 @@ function App() {
           onClose={() => setShowInpFilesModal(false)}
           onUploadClick={() => {
             setShowUploadModal(true)
+            setShowInpFilesModal(false)
+          }}
+          onLoad={async (id) => {
+            await handleLoadInpFile(id)
             setShowInpFilesModal(false)
           }}
         />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -51,10 +51,7 @@ function App() {
       throw new Error('Loaded INP file is missing valid coordinate data.')
     }
 
-    setCoordinates([])
-    setTimeout(() => {
-      setCoordinates(normalized)
-    }, 0)
+    setCoordinates(normalized)
   }, [setCoordinates])
 
   return (

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -7,11 +7,12 @@ function formatDate(value) {
   return date.toLocaleString()
 }
 
-function InpFilesModal({ onClose, onUploadClick }) {
+function InpFilesModal({ onClose, onUploadClick, onLoad }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [deletingId, setDeletingId] = useState(null)
+  const [loadingId, setLoadingId] = useState(null)
 
   useEffect(() => {
     let isMounted = true
@@ -79,6 +80,19 @@ function InpFilesModal({ onClose, onUploadClick }) {
     }
   }
 
+  const handleLoad = async (id) => {
+    if (!onLoad) return
+    setError(null)
+    setLoadingId(id)
+    try {
+      await onLoad(id)
+    } catch (err) {
+      setError(err.message || 'Failed to load the selected INP file.')
+    } finally {
+      setLoadingId(null)
+    }
+  }
+
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="inp-files-title">
       <div className="modal">
@@ -119,11 +133,22 @@ function InpFilesModal({ onClose, onUploadClick }) {
                     <td>{file.filename || 'Unnamed file'}</td>
                     <td>{formatDate(file.uploadedAt)}</td>
                     <td className="actions-cell">
+                      {onLoad && (
+                        <button
+                          type="button"
+                          className="modal-action"
+                          onClick={() => handleLoad(file._id)}
+                          disabled={loadingId === file._id || deletingId === file._id}
+                          aria-label={`Load ${file.filename || 'stored INP file'}`}
+                        >
+                          {loadingId === file._id ? 'Loading…' : 'Load'}
+                        </button>
+                      )}
                       <button
                         type="button"
                         className="modal-action"
                         onClick={() => handleDelete(file._id)}
-                        disabled={deletingId === file._id}
+                        disabled={deletingId === file._id || loadingId === file._id}
                         aria-label={`Delete ${file.filename || 'stored INP file'}`}
                       >
                         {deletingId === file._id ? 'Deleting…' : 'Delete'}

--- a/client/src/ParseForm.jsx
+++ b/client/src/ParseForm.jsx
@@ -1,23 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-
-const normalizeCoordinates = (coordinates) => {
-  if (!Array.isArray(coordinates)) return null
-
-  const normalized = []
-  for (const coord of coordinates) {
-    if (!coord || typeof coord !== 'object' || Array.isArray(coord)) return null
-    const { id, x, y } = coord
-    if (id === undefined || x === undefined || y === undefined) return null
-
-    const xNum = Number(x)
-    const yNum = Number(y)
-    if (!Number.isFinite(xNum) || !Number.isFinite(yNum)) return null
-
-    normalized.push({ id: String(id), x: xNum, y: yNum })
-  }
-
-  return normalized
-}
+import normalizeCoordinates from './normalizeCoordinates'
 
 function ParseForm({ setCoordinates, onClose }) {
   const [title, setTitle] = useState('')

--- a/client/src/normalizeCoordinates.js
+++ b/client/src/normalizeCoordinates.js
@@ -1,0 +1,18 @@
+export default function normalizeCoordinates(coordinates) {
+  if (!Array.isArray(coordinates)) return null
+
+  const normalized = []
+  for (const coord of coordinates) {
+    if (!coord || typeof coord !== 'object' || Array.isArray(coord)) return null
+    const { id, x, y } = coord
+    if (id === undefined || x === undefined || y === undefined) return null
+
+    const xNum = Number(x)
+    const yNum = Number(y)
+    if (!Number.isFinite(xNum) || !Number.isFinite(yNum)) return null
+
+    normalized.push({ id: String(id), x: xNum, y: yNum })
+  }
+
+  return normalized
+}

--- a/server.js
+++ b/server.js
@@ -68,13 +68,36 @@ app.get('/api/inp-files', async (req, res) => {
     const db = getDb();
     const files = await db
       .collection('parses')
-      .find({}, { projection: {  title: 1, filename: 1,uploadedAt: 1 } })
+      .find({}, { projection: { title: 1, filename: 1, uploadedAt: 1 } })
       .sort({ uploadedAt: -1 })
       .toArray();
     res.json(files);
   } catch (err) {
     console.error('Failed to fetch INP files', err);
     res.status(500).json({ error: 'Failed to fetch INP files' });
+  }
+});
+
+app.get('/api/inp-files/:id', async (req, res) => {
+  const { id } = req.params;
+  if (!ObjectId.isValid(id)) {
+    return res.status(400).json({ error: 'Invalid INP file id' });
+  }
+
+  try {
+    const db = getDb();
+    const file = await db
+      .collection('parses')
+      .findOne({ _id: new ObjectId(id) }, { projection: { data: 1, title: 1, filename: 1, uploadedAt: 1 } });
+
+    if (!file) {
+      return res.status(404).json({ error: 'INP file not found' });
+    }
+
+    return res.json(file);
+  } catch (err) {
+    console.error('Failed to load INP file', err);
+    return res.status(500).json({ error: 'Failed to load INP file' });
   }
 });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -133,6 +133,63 @@ describe('GET /api/inp-files', () => {
   });
 });
 
+describe('GET /api/inp-files/:id', () => {
+  it('returns stored INP file data when found', async () => {
+    const record = {
+      _id: '507f1f77bcf86cd799439011',
+      filename: 'sample.inp',
+      title: 'Sample',
+      uploadedAt: '2024-01-01T00:00:00.000Z',
+      data: { COORDINATES: [{ id: 'n1', x: 1, y: 2 }] },
+    };
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({
+        findOne: () => Promise.resolve(record),
+      }),
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(record);
+  });
+
+  it('returns 400 for an invalid id', async () => {
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files/not-an-id');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid INP file id');
+  });
+
+  it('returns 404 when record is missing', async () => {
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockReturnValue({
+      collection: () => ({
+        findOne: () => Promise.resolve(null),
+      }),
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('INP file not found');
+  });
+
+  it('returns 500 when database access fails', async () => {
+    const db = require('../server/db');
+    vi.spyOn(db, 'getDb').mockImplementation(() => {
+      throw new Error('no db');
+    });
+    vi.resetModules();
+    const { default: app } = await import('../server.js');
+    const res = await request(app).get('/api/inp-files/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to load INP file');
+  });
+});
+
 describe('DELETE /api/inp-files/:id', () => {
   it('returns 400 for an invalid id', async () => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- add reusable coordinate normalization helper for parsing stored INP data
- extend stored INP modal with a load action that retrieves file data, clears the map, and closes the modal once complete
- expose a backend endpoint and tests for fetching stored INP file payloads by id, wiring the client to update the displayed coordinates

## Testing
- npm --prefix client run lint
- npm --prefix client test -- --watch=false
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68ce2f5c13288332a9a19913bcc716a3