### PR TITLE
Add report upload modal for stored INP files

### DIFF
--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -45,8 +45,9 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
         setError(err.message)
         setFiles([])
       } finally {
-        if (!isMountedRef.current) return
-        setLoading(false)
+        if (isMountedRef.current) {
+          setLoading(false)
+        }
       }
     },
     []

--- a/client/src/InpFilesModal.jsx
+++ b/client/src/InpFilesModal.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import ReportUploadModal from './ReportUploadModal'
 
 function formatDate(value) {
   if (!value) return 'Unknown'
@@ -13,48 +14,57 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
   const [error, setError] = useState(null)
   const [deletingId, setDeletingId] = useState(null)
   const [loadingId, setLoadingId] = useState(null)
+  const [reportTarget, setReportTarget] = useState(null)
+  const [statusMessage, setStatusMessage] = useState(null)
+  const isMountedRef = useRef(true)
 
   useEffect(() => {
-    let isMounted = true
-    const controller = new AbortController()
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
-    const loadFiles = async () => {
+  const loadFiles = useCallback(
+    async (signal) => {
       try {
         setLoading(true)
         setError(null)
         const response = await fetch('/api/inp-files', {
-          signal: controller.signal,
+          signal,
         })
         if (!response.ok) {
           throw new Error('Unable to load INP file index.')
         }
         const data = await response.json()
-        if (isMounted) {
-          setFiles(Array.isArray(data) ? data : [])
-        }
+        if (!isMountedRef.current) return
+        setFiles(Array.isArray(data) ? data : [])
       } catch (err) {
         if (err.name === 'AbortError') return
-        if (isMounted) {
-          setError(err.message)
-          setFiles([])
-        }
+        if (!isMountedRef.current) return
+        setError(err.message)
+        setFiles([])
       } finally {
-        if (isMounted) {
-          setLoading(false)
-        }
+        if (!isMountedRef.current) return
+        setLoading(false)
       }
-    }
+    },
+    []
+  )
 
-    loadFiles()
+  useEffect(() => {
+    const controller = new AbortController()
+
+    loadFiles(controller.signal)
 
     return () => {
-      isMounted = false
       controller.abort()
     }
-  }, [])
+  }, [loadFiles])
 
   const handleDelete = async (id) => {
     setError(null)
+    setStatusMessage(null)
     setDeletingId(id)
     try {
       const response = await fetch(`/api/inp-files/${id}`, {
@@ -83,6 +93,7 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
   const handleLoad = async (id) => {
     if (!onLoad) return
     setError(null)
+    setStatusMessage(null)
     setLoadingId(id)
     try {
       await onLoad(id)
@@ -91,6 +102,12 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
     } finally {
       setLoadingId(null)
     }
+  }
+
+  const handleReportUploadSuccess = () => {
+    setReportTarget(null)
+    setStatusMessage('Report uploaded successfully.')
+    loadFiles()
   }
 
   return (
@@ -114,7 +131,10 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
             <p>Loading INP files...</p>
           ) : error ? (
             <div className="error-banner">{error}</div>
-          ) : files.length > 0 ? (
+          ) : (
+            statusMessage && <div className="success-banner">{statusMessage}</div>
+          )}
+          {!loading && !error && files.length > 0 ? (
             <table className="modal-table">
               <thead>
                 <tr>
@@ -153,16 +173,34 @@ function InpFilesModal({ onClose, onUploadClick, onLoad }) {
                       >
                         {deletingId === file._id ? 'Deleting…' : 'Delete'}
                       </button>
+                      <button
+                        type="button"
+                        className="modal-action"
+                        onClick={() => {
+                          setStatusMessage(null)
+                          setReportTarget(file)
+                        }}
+                        aria-label={`Upload report for ${file.filename || 'stored INP file'}`}
+                      >
+                        Upload Report
+                      </button>
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-          ) : (
+          ) : !loading && !error ? (
             <p>No INP files have been stored yet.</p>
-          )}
+          ) : null}
         </div>
       </div>
+      {reportTarget && (
+        <ReportUploadModal
+          file={reportTarget}
+          onClose={() => setReportTarget(null)}
+          onSuccess={handleReportUploadSuccess}
+        />
+      )}
     </div>
   )
 }

--- a/client/src/InpFilesModal.test.jsx
+++ b/client/src/InpFilesModal.test.jsx
@@ -78,4 +78,98 @@ describe('InpFilesModal', () => {
 
     expect(onUploadClick).toHaveBeenCalled()
   })
+
+  it('renders upload report buttons for each stored file', async () => {
+    globalThis.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          _id: 'abc123',
+          filename: 'Example.inp',
+          title: 'Example model',
+          uploadedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    render(<InpFilesModal onClose={onClose} onUploadClick={onUploadClick} />)
+
+    const uploadReportButton = await screen.findByRole('button', {
+      name: 'Upload report for Example.inp',
+    })
+
+    expect(uploadReportButton).toBeInTheDocument()
+  })
+
+  it('opens the report upload modal and posts the selected file', async () => {
+    const fileRecord = {
+      _id: 'abc123',
+      filename: 'Example.inp',
+      title: 'Example model',
+      uploadedAt: '2024-01-01T00:00:00.000Z',
+    }
+
+    globalThis.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [fileRecord],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [fileRecord],
+      })
+
+    render(<InpFilesModal onClose={onClose} onUploadClick={onUploadClick} />)
+
+    const uploadReportButton = await screen.findByRole('button', {
+      name: 'Upload report for Example.inp',
+    })
+
+    fireEvent.click(uploadReportButton)
+
+    const modal = await screen.findByRole('dialog', { name: 'Upload Report' })
+    expect(modal).toBeInTheDocument()
+
+    const fileInput = screen.getByLabelText('Report file')
+    const reportFile = new File(['test content'], 'example.rpt', {
+      type: 'text/plain',
+    })
+
+    fireEvent.change(fileInput, { target: { files: [reportFile] } })
+
+    const submitButton = screen.getByRole('button', { name: 'Upload' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/inp-files/abc123/report',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+        })
+      )
+    })
+
+    const [, postOptions] = globalThis.fetch.mock.calls[1]
+    expect(postOptions.body.get('file')).toBe(reportFile)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(
+        3,
+        '/api/inp-files',
+        expect.objectContaining({ signal: undefined })
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Upload Report' })).not.toBeInTheDocument()
+    })
+
+    expect(await screen.findByText('Report uploaded successfully.')).toBeInTheDocument()
+  })
 })

--- a/client/src/ReportUploadModal.jsx
+++ b/client/src/ReportUploadModal.jsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+function ReportUploadModal({ file, onClose, onSuccess }) {
+  const [error, setError] = useState(null)
+  const [uploading, setUploading] = useState(false)
+  const modalRef = useRef(null)
+  const fileInputRef = useRef(null)
+  const focusableElementsRef = useRef([])
+
+  const collectFocusableElements = useCallback(() => {
+    const modal = modalRef.current
+    if (!modal) return
+
+    const focusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([type="hidden"]):not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(', ')
+
+    focusableElementsRef.current = Array.from(modal.querySelectorAll(focusableSelector)).filter(
+      (element) => !element.hasAttribute('aria-hidden')
+    )
+
+    if (focusableElementsRef.current.length === 0) {
+      modal.focus()
+    }
+  }, [])
+
+  useEffect(() => {
+    collectFocusableElements()
+  }, [collectFocusableElements, uploading, error])
+
+  useEffect(() => {
+    const modal = modalRef.current
+    if (!modal) return
+
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Tab') return
+
+      const focusableElements = focusableElementsRef.current
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const [firstElement] = focusableElements
+      const lastElement = focusableElements[focusableElements.length - 1]
+      const activeElement = document.activeElement
+
+      if (event.shiftKey) {
+        if (activeElement === firstElement || !modal.contains(activeElement)) {
+          lastElement.focus()
+          event.preventDefault()
+        }
+        return
+      }
+
+      if (activeElement === lastElement || !modal.contains(activeElement)) {
+        firstElement.focus()
+        event.preventDefault()
+      }
+    }
+
+    modal.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      modal.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [collectFocusableElements])
+
+  useEffect(() => {
+    fileInputRef.current?.focus()
+  }, [])
+
+  const handleBackdropMouseDown = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose?.()
+    }
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    const reportFile = fileInputRef.current?.files?.[0]
+    if (!reportFile) {
+      setError('Please choose a report file to upload.')
+      return
+    }
+
+    if (!reportFile.name.toLowerCase().endsWith('.rpt')) {
+      setError('Invalid file type. Please upload a .rpt file.')
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', reportFile)
+
+    setUploading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/inp-files/${file._id}/report`, {
+        method: 'POST',
+        body: formData,
+      })
+      if (!response.ok) {
+        let message = 'Failed to upload report.'
+        try {
+          const body = await response.json()
+          if (body?.error) {
+            message = body.error
+          }
+        } catch (err) {
+          console.debug('Failed to parse report upload error response', err)
+        }
+        throw new Error(message)
+      }
+      onSuccess?.()
+    } catch (err) {
+      setError(err.message || 'Failed to upload report.')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div
+      className="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="report-upload-title"
+      onMouseDown={handleBackdropMouseDown}
+    >
+      <div className="modal" role="document" tabIndex={-1} ref={modalRef}>
+        <div className="modal-header">
+          <h2 id="report-upload-title">Upload Report</h2>
+          <button
+            type="button"
+            className="modal-close"
+            onClick={() => onClose?.()}
+            aria-label="Close report upload"
+          >
+            ×
+          </button>
+        </div>
+        <div className="modal-body">
+          <p className="modal-subtitle">
+            {`Select a report for ${file?.title || file?.filename || 'this INP file'}.`}
+          </p>
+          <form onSubmit={handleSubmit}>
+            <label htmlFor="report-file-input">Report file</label>
+            <input
+              ref={fileInputRef}
+              id="report-file-input"
+              type="file"
+              name="report"
+              accept=".rpt"
+            />
+            <div className="modal-actions">
+              <button type="submit" disabled={uploading}>
+                {uploading ? 'Uploading…' : 'Upload'}
+              </button>
+              <button type="button" onClick={() => onClose?.()} disabled={uploading}>
+                Cancel
+              </button>
+            </div>
+          </form>
+          {error && <div className="error-banner">{error}</div>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ReportUploadModal

--- a/client/src/ReportUploadModal.test.jsx
+++ b/client/src/ReportUploadModal.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import ReportUploadModal from './ReportUploadModal'
+
+describe('ReportUploadModal', () => {
+  const originalFetch = globalThis.fetch
+  let onClose
+  let onSuccess
+  const fileRecord = {
+    _id: 'abc123',
+    filename: 'Example.inp',
+    title: 'Example model',
+  }
+
+  beforeEach(() => {
+    onClose = vi.fn()
+    onSuccess = vi.fn()
+    globalThis.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    globalThis.fetch = originalFetch
+  })
+
+  it('requires a report file to be selected before uploading', async () => {
+    render(<ReportUploadModal file={fileRecord} onClose={onClose} onSuccess={onSuccess} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    expect(
+      await screen.findByText('Please choose a report file to upload.')
+    ).toBeInTheDocument()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects files without the .rpt extension', async () => {
+    render(<ReportUploadModal file={fileRecord} onClose={onClose} onSuccess={onSuccess} />)
+
+    const fileInput = screen.getByLabelText('Report file')
+    const invalidFile = new File(['invalid'], 'example.txt', { type: 'text/plain' })
+
+    fireEvent.change(fileInput, { target: { files: [invalidFile] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    expect(
+      await screen.findByText('Invalid file type. Please upload a .rpt file.')
+    ).toBeInTheDocument()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('posts the selected report file to the API', async () => {
+    globalThis.fetch.mockResolvedValueOnce({ ok: true })
+
+    render(<ReportUploadModal file={fileRecord} onClose={onClose} onSuccess={onSuccess} />)
+
+    const fileInput = screen.getByLabelText('Report file')
+    const reportFile = new File(['rpt'], 'example.rpt', { type: 'text/plain' })
+
+    fireEvent.change(fileInput, { target: { files: [reportFile] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }))
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/api/inp-files/abc123/report',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+        })
+      )
+    })
+
+    const [, options] = globalThis.fetch.mock.calls[0]
+    expect(options.body.get('file')).toBe(reportFile)
+    expect(onSuccess).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add report upload state and messaging to the stored INP files modal
- create a report upload modal that posts .rpt files and traps focus consistently
- expand frontend tests to cover the new workflow and validation paths

## Testing
- npm --prefix client test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dccdb8b0a48332b3fbdb4ba8e5da4b