### PR TITLE
Refactor report parser to async file reads

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ app.post('/api/inp-files/:id/report', upload.single('file'), async (req, res) =>
 
     let parsedReport;
     try {
-      parsedReport = parseReport(req.file.path);
+      parsedReport = await parseReport(req.file.path);
     } catch (err) {
       if (err instanceof ReportParseError) {
         return res.status(422).json({ error: err.message });

--- a/server/reportParser.js
+++ b/server/reportParser.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 
 class ReportParseError extends Error {
   constructor(message) {
@@ -77,8 +77,8 @@ const FLOW_ROUTING_LABELS = {
   },
 };
 
-function parseReport(filePath) {
-  const content = fs.readFileSync(filePath, 'utf8');
+async function parseReport(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
   if (!content.trim()) {
     throw new ReportParseError('Report file is empty');
   }

--- a/test/reportParser.test.js
+++ b/test/reportParser.test.js
@@ -6,9 +6,9 @@ import { parseReport, ReportParseError } from '../server/reportParser';
 const dataDir = __dirname;
 
 describe('parseReport', () => {
-  it('parses element counts, summaries, and continuity metrics from a report file', () => {
+  it('parses element counts, summaries, and continuity metrics from a report file', async () => {
     const file = path.join(dataDir, 'data', 'sample-report.rpt');
-    const result = parseReport(file);
+    const result = await parseReport(file);
 
     expect(result.elementCount).toEqual({
       rainGages: 0,
@@ -61,21 +61,25 @@ describe('parseReport', () => {
     expect(result.flowRoutingContinuity.continuityErrorPercent).toBeCloseTo(1.078, 3);
   });
 
-  it('throws when a required element count is missing', () => {
+  it('throws when a required element count is missing', async () => {
     const file = path.join(dataDir, 'data', 'missing-field-report.rpt');
-    expect(() => parseReport(file)).toThrow(ReportParseError);
-    expect(() => parseReport(file)).toThrow(/Missing required element count: Number of links/);
+    await expect(parseReport(file)).rejects.toThrow(ReportParseError);
+    await expect(parseReport(file)).rejects.toThrow(
+      /Missing required element count: Number of links/
+    );
   });
 
-  it('throws when numeric fields cannot be parsed', () => {
+  it('throws when numeric fields cannot be parsed', async () => {
     const file = path.join(dataDir, 'data', 'invalid-number-report.rpt');
-    expect(() => parseReport(file)).toThrow(ReportParseError);
-    expect(() => parseReport(file)).toThrow(/Invalid numeric value for Number of nodes/);
+    await expect(parseReport(file)).rejects.toThrow(ReportParseError);
+    await expect(parseReport(file)).rejects.toThrow(
+      /Invalid numeric value for Number of nodes/
+    );
   });
 
-  it('throws when report file is empty', () => {
+  it('throws when report file is empty', async () => {
     const file = path.join(dataDir, 'data', 'empty-report.rpt');
-    expect(() => parseReport(file)).toThrow(ReportParseError);
-    expect(() => parseReport(file)).toThrow(/Report file is empty/);
+    await expect(parseReport(file)).rejects.toThrow(ReportParseError);
+    await expect(parseReport(file)).rejects.toThrow(/Report file is empty/);
   });
 });


### PR DESCRIPTION
## Summary
- switch the report parser to use async file reads and return a promise
- update the report upload API endpoint to await the async parser
- adjust parser unit tests to use async expectations

## Testing
- npm run test:server

------
https://chatgpt.com/codex/tasks/task_e_68dd3f1c02dc8332bad55325388a1871